### PR TITLE
mcp prompt support

### DIFF
--- a/deploy/docker/multi/web/nginx.conf
+++ b/deploy/docker/multi/web/nginx.conf
@@ -17,6 +17,11 @@ http {
         server localhost:5234;
     }
 
+    # MCP Gateway
+    upstream mcp-gateway {
+        server mcp-gateway:5236;
+    }
+
     server {
         listen 80;
         server_name localhost;
@@ -44,5 +49,13 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
+
+        location /mcp/ {
+            proxy_pass http://mcp-gateway/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }        
     }
 } 

--- a/internal/apiserver/handler/mcp.go
+++ b/internal/apiserver/handler/mcp.go
@@ -353,6 +353,7 @@ func (h *MCP) HandleListMCPServers(c *gin.Context) {
 			Tenant:     server.Tenant,
 			McpServers: dto.FromMCPServerConfigs(server.McpServers),
 			Tools:      dto.FromToolConfigs(server.Tools),
+			Prompts:    dto.FromPromptConfigs(server.Prompts),
 			Servers:    dto.FromServerConfigs(server.Servers),
 			Routers:    dto.FromRouterConfigs(server.Routers),
 			CreatedAt:  server.CreatedAt,

--- a/internal/common/config/mcp.go
+++ b/internal/common/config/mcp.go
@@ -27,6 +27,7 @@ type (
 		Routers    []RouterConfig    `json:"routers,omitempty" yaml:"routers,omitempty"`
 		Servers    []ServerConfig    `json:"servers,omitempty" yaml:"servers,omitempty"`
 		Tools      []ToolConfig      `json:"tools,omitempty" yaml:"tools,omitempty"`
+		Prompts    []PromptConfig    `json:"prompts,omitempty" yaml:"prompts,omitempty"`
 		McpServers []MCPServerConfig `json:"mcpServers,omitempty" yaml:"mcpServers,omitempty"` // proxy mcp servers
 	}
 
@@ -110,6 +111,7 @@ type (
 		Routers    string          `json:"routers" yaml:"routers"`
 		Servers    string          `json:"servers" yaml:"servers"`
 		Tools      string          `json:"tools" yaml:"tools"`
+		Prompts    string          `json:"prompts" yaml:"prompts"`
 		McpServers string          `json:"mcp_servers" yaml:"mcp_servers"`
 		IsActive   bool            `json:"is_active" yaml:"is_active"` // indicates if this version is currently active
 		Hash       string          `json:"hash" yaml:"hash"`           // hash of the configuration content
@@ -118,6 +120,29 @@ type (
 	// Auth represents authentication configuration
 	Auth struct {
 		Mode cnst.AuthMode `json:"mode" yaml:"mode"`
+	}
+
+	PromptConfig struct {
+		Name        string              `json:"name" yaml:"name"`
+		Description string              `json:"description" yaml:"description"`
+		Arguments   []PromptArgument    `json:"arguments" yaml:"arguments"`
+		PromptResponse []PromptResponse `json:"promptResponse,omitempty" yaml:"promptResponse,omitempty"`
+	}
+
+	PromptArgument struct {
+		Name        string `json:"name" yaml:"name"`
+		Description string `json:"description" yaml:"description"`
+		Required    bool   `json:"required" yaml:"required"`
+	}
+
+	PromptResponse struct {
+		Role    string                `json:"role" yaml:"role"`
+		Content PromptResponseContent `json:"content" yaml:"content"`
+	}
+
+	PromptResponseContent struct {
+		Type string `json:"type" yaml:"type"`
+		Text string `json:"text" yaml:"text"`
 	}
 )
 
@@ -167,5 +192,33 @@ func (t *ToolConfig) ToToolSchema() mcp.ToolSchema {
 			Properties: properties,
 			Required:   required,
 		},
+	}
+}
+
+// ToPromptSchema converts a PromptConfig to a PromptSchema
+func (t *PromptConfig) ToPromptSchema() mcp.PromptSchema {
+	args := make([]mcp.PromptArgumentSchema, len(t.Arguments))
+	for i, a := range t.Arguments {
+		args[i] = mcp.PromptArgumentSchema{
+			Name:        a.Name,
+			Description: a.Description,
+			Required:    a.Required,
+		}
+	}
+	var responses []mcp.PromptResponseSchema
+	for _, r := range t.PromptResponse {
+		responses = append(responses, mcp.PromptResponseSchema{
+			Role: r.Role,
+			Content: mcp.PromptResponseContentSchema{
+				Type: r.Content.Type,
+				Text: r.Content.Text,
+			},
+		})
+	}
+	return mcp.PromptSchema{
+		Name:          t.Name,
+		Description:   t.Description,
+		Arguments:     args,
+		PromptResponse: responses,
 	}
 }

--- a/internal/common/dto/mcp.go
+++ b/internal/common/dto/mcp.go
@@ -11,6 +11,7 @@ type MCPServer struct {
 	Tenant     string            `json:"tenant"`
 	McpServers []MCPServerConfig `json:"mcpServers,omitempty"`
 	Tools      []ToolConfig      `json:"tools,omitempty"`
+	Prompts    []PromptConfig    `json:"prompts,omitempty"`
 	Servers    []ServerConfig    `json:"servers,omitempty"`
 	Routers    []RouterConfig    `json:"routers,omitempty"`
 	CreatedAt  time.Time         `json:"createdAt"`
@@ -26,6 +27,7 @@ type MCPConfig struct {
 	Routers    []RouterConfig    `json:"routers,omitempty"`
 	Servers    []ServerConfig    `json:"servers,omitempty"`
 	Tools      []ToolConfig      `json:"tools,omitempty"`
+	Prompts    []PromptConfig    `json:"prompts,omitempty"`
 	McpServers []MCPServerConfig `json:"mcpServers,omitempty"`
 }
 
@@ -101,6 +103,30 @@ type ItemsConfig struct {
 	Enum []string `json:"enum,omitempty"`
 }
 
+
+type PromptConfig struct {
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	Arguments   []PromptArgument    `json:"arguments"`
+	PromptResponse []PromptResponse `json:"promptResponse,omitempty"`
+}
+
+type PromptArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Required    bool   `json:"required"`
+}
+
+type PromptResponse struct {
+	Role    string                `json:"role"`
+	Content PromptResponseContent `json:"content"`
+}
+
+type PromptResponseContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
 // FromConfig converts a config.MCPConfig to dto.MCPServer
 func FromConfig(cfg *config.MCPConfig) MCPServer {
 	return MCPServer{
@@ -108,6 +134,7 @@ func FromConfig(cfg *config.MCPConfig) MCPServer {
 		Tenant:     cfg.Tenant,
 		McpServers: FromMCPServerConfigs(cfg.McpServers),
 		Tools:      FromToolConfigs(cfg.Tools),
+		Prompts:    FromPromptConfigs(cfg.Prompts),
 		Servers:    FromServerConfigs(cfg.Servers),
 		Routers:    FromRouterConfigs(cfg.Routers),
 		CreatedAt:  cfg.CreatedAt,
@@ -255,5 +282,58 @@ func FromAuthConfig(cfg *config.Auth) *Auth {
 	}
 	return &Auth{
 		Mode: string(cfg.Mode),
+	}
+}
+
+// FromPromptConfigs converts a slice of config.PromptConfig to dto.PromptConfig
+func FromPromptConfigs(cfgs []config.PromptConfig) []PromptConfig {
+	if cfgs == nil {
+		return nil
+	}
+	result := make([]PromptConfig, len(cfgs))
+	for i, cfg := range cfgs {
+		result[i] = PromptConfig{
+			Name:        cfg.Name,
+			Description: cfg.Description,
+			Arguments:   FromPromptArguments(cfg.Arguments),
+			PromptResponse: FromPromptResponses(cfg.PromptResponse),
+		}
+	}
+	return result
+}
+
+func FromPromptArguments(cfgs []config.PromptArgument) []PromptArgument {
+	if cfgs == nil {
+		return nil
+	}
+	result := make([]PromptArgument, len(cfgs))
+	for i, cfg := range cfgs {
+		result[i] = PromptArgument{
+			Name:        cfg.Name,
+			Description: cfg.Description,
+			Required:    cfg.Required,
+		}
+	}
+	return result
+}
+
+func FromPromptResponses(cfgs []config.PromptResponse) []PromptResponse {
+	if cfgs == nil {
+		return nil
+	}
+	result := make([]PromptResponse, len(cfgs))
+	for i, cfg := range cfgs {
+		result[i] = PromptResponse{
+			Role:    cfg.Role,
+			Content: FromPromptResponseContent(cfg.Content),
+		}
+	}
+	return result
+}
+
+func FromPromptResponseContent(cfg config.PromptResponseContent) PromptResponseContent {
+	return PromptResponseContent{
+		Type: cfg.Type,
+		Text: cfg.Text,
 	}
 }

--- a/internal/core/mcpproxy/sse.go
+++ b/internal/core/mcpproxy/sse.go
@@ -186,3 +186,13 @@ func (t *SSETransport) CallTool(ctx context.Context, params mcp.CallToolParams, 
 	t.Stop(ctx)
 	return convertMCPGoResult(mcpResult), nil
 }
+
+// FetchPrompts returns all prompts (stub implementation)
+func (t *SSETransport) FetchPrompts(ctx context.Context) ([]mcp.PromptSchema, error) {
+	return nil, nil
+}
+
+// FetchPrompt returns a specific prompt by name (stub implementation)
+func (t *SSETransport) FetchPrompt(ctx context.Context, name string) (*mcp.PromptSchema, error) {
+	return nil, nil
+}

--- a/internal/core/mcpproxy/stdio.go
+++ b/internal/core/mcpproxy/stdio.go
@@ -274,3 +274,13 @@ func (t *StdioTransport) CallTool(ctx context.Context, params mcp.CallToolParams
 
 	return result, nil
 }
+
+// FetchPrompts returns all prompts (stub implementation)
+func (t *StdioTransport) FetchPrompts(ctx context.Context) ([]mcp.PromptSchema, error) {
+	return nil, nil
+}
+
+// FetchPrompt returns a specific prompt by name (stub implementation)
+func (t *StdioTransport) FetchPrompt(ctx context.Context, name string) (*mcp.PromptSchema, error) {
+	return nil, nil
+}

--- a/internal/core/mcpproxy/streamable.go
+++ b/internal/core/mcpproxy/streamable.go
@@ -176,3 +176,13 @@ func (t *StreamableTransport) CallTool(ctx context.Context, params mcp.CallToolP
 
 	return convertMCPGoResult(res), nil
 }
+
+// FetchPrompts returns all prompts (stub implementation)
+func (t *StreamableTransport) FetchPrompts(ctx context.Context) ([]mcp.PromptSchema, error) {
+	return nil, nil
+}
+
+// FetchPrompt returns a specific prompt by name (stub implementation)
+func (t *StreamableTransport) FetchPrompt(ctx context.Context, name string) (*mcp.PromptSchema, error) {
+	return nil, nil
+}

--- a/internal/core/mcpproxy/transport.go
+++ b/internal/core/mcpproxy/transport.go
@@ -37,6 +37,11 @@ type Transport interface {
 
 	// IsRunning returns true if the transport is running
 	IsRunning() bool
+
+	// FetchPrompts fetches the list of available prompts
+	FetchPrompts(ctx context.Context) ([]mcp.PromptSchema, error)
+	// FetchPrompt fetches a specific prompt by name
+	FetchPrompt(ctx context.Context, name string) (*mcp.PromptSchema, error)
 }
 
 // NewTransport creates transport based on the configuration

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -414,6 +414,144 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 		}
 
 		s.sendSuccessResponse(c, conn, req, result, true)
+
+	case mcp.PromptsList:
+		protoType := s.state.GetProtoType(conn.Meta().Prefix)
+		if protoType == "" {
+			s.sendProtocolError(c, req.Id, "Server configuration not found", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+			return
+		}
+
+		var prompts []mcp.PromptSchema
+		var err error
+		switch protoType {
+		case cnst.BackendProtoHttp:
+			prompts = s.state.GetPromptSchemas(conn.Meta().Prefix)
+			if len(prompts) == 0 {
+				prompts = []mcp.PromptSchema{}
+			}
+		case cnst.BackendProtoStdio, cnst.BackendProtoSSE, cnst.BackendProtoStreamable:
+			transport := s.state.GetTransport(conn.Meta().Prefix)
+			if transport == nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompts", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+
+			prompts, err = transport.FetchPrompts(c.Request.Context())
+			if err != nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompts", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+		default:
+			s.sendProtocolError(c, req.Id, "Unsupported protocol type", http.StatusBadRequest, mcp.ErrorCodeInvalidParams)
+			return
+		}
+
+		result := struct {
+			Prompts []mcp.PromptSchema `json:"prompts"`
+		}{
+			Prompts: prompts,
+		}
+		s.sendSuccessResponse(c, conn, req, result, true)
+	case mcp.PromptsGet:
+		protoType := s.state.GetProtoType(conn.Meta().Prefix)
+		if protoType == "" {
+			s.sendProtocolError(c, req.Id, "Server configuration not found", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+			return
+		}
+
+		var params struct {
+			Name string `json:"name"`
+			Arguments map[string]string `json:"arguments"`
+		}
+
+		if err := json.Unmarshal(req.Params, &params); err != nil || params.Name == "" {
+			s.sendProtocolError(c, req.Id, "Invalid prompt get parameters", http.StatusBadRequest, mcp.ErrorCodeInvalidParams)
+			return
+		}
+
+		var prompt *mcp.PromptSchema
+		var err error
+		switch protoType {
+		case cnst.BackendProtoHttp:
+			prompts := s.state.GetPromptSchemas(conn.Meta().Prefix)
+			for i := range prompts {
+				if prompts[i].Name == params.Name {
+					prompt = &prompts[i]
+					break
+				}
+			}
+		case cnst.BackendProtoStdio, cnst.BackendProtoSSE, cnst.BackendProtoStreamable:
+			transport := s.state.GetTransport(conn.Meta().Prefix)
+			if transport == nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompt", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+			prompt, err = transport.FetchPrompt(c.Request.Context(), params.Name)
+			if err != nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompt", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+		default:
+			s.sendProtocolError(c, req.Id, "Unsupported protocol type", http.StatusBadRequest, mcp.ErrorCodeInvalidParams)
+			return
+		}
+
+		if prompt == nil {
+			s.sendProtocolError(c, req.Id, "Prompt not found", http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
+			return
+		}
+
+		// Build the response with argument substitution
+		var argsMap map[string]string
+		if req.Params != nil {
+			_ = json.Unmarshal(req.Params, &argsMap)
+		}
+		argsMap = params.Arguments
+
+		resp := struct {
+			Description string `json:"description"`
+			Messages    []struct {
+				Role    string `json:"role"`
+				Content struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"messages"`
+		}{
+			Description: prompt.Description,
+		}
+
+		for _, msg := range prompt.PromptResponse {
+			text := msg.Content.Text
+			// Replace {argument} placeholders with values from argsMap
+			for _, arg := range prompt.Arguments {
+				if val, ok := argsMap[arg.Name]; ok {
+					text = strings.ReplaceAll(text, "{"+arg.Name+"}", val)
+				}
+			}
+			resp.Messages = append(resp.Messages, struct {
+				Role    string `json:"role"`
+				Content struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			}{
+				Role: msg.Role,
+				Content: struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				}{
+					Type: msg.Content.Type,
+					Text: text,
+				},
+			})
+		}
+		
+		s.sendSuccessResponse(c, conn, req, resp, true)
+		return
+
+
 	default:
 		s.sendProtocolError(c, req.Id, "Unknown method", http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 	}

--- a/internal/core/state/getter.go
+++ b/internal/core/state/getter.go
@@ -13,6 +13,8 @@ func (s *State) getRuntime(prefix string) runtimeUnit {
 		return runtimeUnit{
 			tools:       make(map[toolName]*config.ToolConfig),
 			toolSchemas: make([]mcp.ToolSchema, 0),
+			prompts:       make(map[promptName]*config.PromptConfig),
+			promptSchemas: make([]mcp.PromptSchema, 0),
 		}
 	}
 	return runtime
@@ -128,4 +130,20 @@ func (s *State) GetSSEPrefix(prefix string) string {
 		return runtime.router.SSEPrefix
 	}
 	return ""
+}
+
+func (s *State) GetPrompt(prefix, name string) *config.PromptConfig {
+	runtime, ok := s.runtime[uriPrefix(prefix)]
+	if !ok {
+		return nil
+	}
+	return runtime.prompts[promptName(name)]
+}
+
+func (s *State) GetPromptSchemas(prefix string) []mcp.PromptSchema {
+	runtime, ok := s.runtime[uriPrefix(prefix)]
+	if !ok {
+		return nil
+	}
+	return runtime.promptSchemas
 }

--- a/internal/core/state/state.go
+++ b/internal/core/state/state.go
@@ -16,6 +16,7 @@ import (
 type (
 	uriPrefix string
 	toolName  string
+	promptName  string
 
 	// State contains all the read-only shared state
 	State struct {
@@ -33,6 +34,9 @@ type (
 
 		tools       map[toolName]*config.ToolConfig
 		toolSchemas []mcp.ToolSchema
+
+		prompts      map[promptName]*config.PromptConfig
+		promptSchemas []mcp.PromptSchema
 	}
 
 	metrics struct {
@@ -116,6 +120,16 @@ func BuildStateFromConfig(ctx context.Context, cfgs []*config.MCPConfig, oldStat
 				runtime.server = &server
 				runtime.tools = allowedTools
 				runtime.toolSchemas = allowedToolSchemas
+				//runtime.prompts = map[promptName]*cfg.Prompts	
+				for i := range cfg.Prompts {
+   					p := &cfg.Prompts[i]
+    				runtime.prompts[promptName(p.Name)] = p
+				}
+				//runtime.promptSchemas = cfg.Prompts.ToPromptSchemas()
+				runtime.promptSchemas = make([]mcp.PromptSchema, len(cfg.Prompts))
+				for i, p := range cfg.Prompts {
+    				runtime.promptSchemas[i] = p.ToPromptSchema()
+				}				
 				newState.runtime[uriPrefix(prefix)] = runtime
 			}
 		}

--- a/internal/core/streamable.go
+++ b/internal/core/streamable.go
@@ -288,6 +288,144 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 		s.sendSuccessResponse(c, conn, req, result, false)
 		return
 
+	case mcp.PromptsList:
+		protoType := s.state.GetProtoType(conn.Meta().Prefix)
+		if protoType == "" {
+			s.sendProtocolError(c, req.Id, "Server configuration not found", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+			return
+		}
+
+		var prompts []mcp.PromptSchema
+		var err error
+		switch protoType {
+		case cnst.BackendProtoHttp:
+			prompts = s.state.GetPromptSchemas(conn.Meta().Prefix)
+			if len(prompts) == 0 {
+				prompts = []mcp.PromptSchema{}
+			}
+		case cnst.BackendProtoStdio, cnst.BackendProtoSSE, cnst.BackendProtoStreamable:
+			transport := s.state.GetTransport(conn.Meta().Prefix)
+			if transport == nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompts", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+
+			prompts, err = transport.FetchPrompts(c.Request.Context())
+			if err != nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompts", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+		default:
+			s.sendProtocolError(c, req.Id, "Unsupported protocol type", http.StatusBadRequest, mcp.ErrorCodeInvalidParams)
+			return
+		}
+
+		s.sendSuccessResponse(c, conn, req, struct {
+			Prompts []mcp.PromptSchema `json:"prompts"`
+		}{
+			Prompts: prompts,
+		}, false)
+		return
+
+	case mcp.PromptsGet:
+		protoType := s.state.GetProtoType(conn.Meta().Prefix)
+		if protoType == "" {
+			s.sendProtocolError(c, req.Id, "Server configuration not found", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+			return
+		}
+
+		var params struct {
+			Name string `json:"name"`
+			Arguments map[string]string `json:"arguments"`
+		}
+		if err := json.Unmarshal(req.Params, &params); err != nil || params.Name == "" {
+			s.sendProtocolError(c, req.Id, "Invalid prompt get parameters", http.StatusBadRequest, mcp.ErrorCodeInvalidParams)
+			return
+		}
+
+
+		var prompt *mcp.PromptSchema
+		var err error
+		switch protoType {
+		case cnst.BackendProtoHttp:
+			prompts := s.state.GetPromptSchemas(conn.Meta().Prefix)
+			for i := range prompts {
+				if prompts[i].Name == params.Name {
+					prompt = &prompts[i]
+					break
+				}
+			}
+			s.logger.Info("PromptsGet-prompt found", zap.String("params.Name", params.Name), zap.String("promptname", prompt.Name))
+		case cnst.BackendProtoStdio, cnst.BackendProtoSSE, cnst.BackendProtoStreamable:
+			transport := s.state.GetTransport(conn.Meta().Prefix)
+			if transport == nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompt", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+			prompt, err = transport.FetchPrompt(c.Request.Context(), params.Name)
+			if err != nil {
+				s.sendProtocolError(c, req.Id, "Failed to fetch prompt", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
+				return
+			}
+		default:
+			s.sendProtocolError(c, req.Id, "Unsupported protocol type", http.StatusBadRequest, mcp.ErrorCodeInvalidParams)
+			return
+		}
+
+		if prompt == nil {
+			s.sendProtocolError(c, req.Id, "Prompt not found", http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
+			return
+		}
+
+		// Build the response with argument substitution
+		var argsMap map[string]string
+		if req.Params != nil {
+			_ = json.Unmarshal(req.Params, &params)	
+		}
+		argsMap = params.Arguments
+		
+		resp := struct {
+			Description string `json:"description"`
+			Messages    []struct {
+				Role    string `json:"role"`
+				Content struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"messages"`
+		}{
+			Description: prompt.Description,
+		}
+					
+		for _, msg := range prompt.PromptResponse {
+			text := msg.Content.Text
+			// Replace {argument} placeholders with values from argsMap
+			for _, arg := range prompt.Arguments {
+				if val, ok := argsMap[arg.Name]; ok {
+					text = strings.ReplaceAll(text, "{"+arg.Name+"}", val)
+				}
+			}
+			resp.Messages = append(resp.Messages, struct {
+				Role    string `json:"role"`
+				Content struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			}{
+				Role: msg.Role,
+				Content: struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				}{
+					Type: msg.Content.Type,
+					Text: text,
+				},
+			})
+		}
+
+		s.sendSuccessResponse(c, conn, req, resp, false)
+		return
+
 	default:
 		s.sendProtocolError(c, req.Id, "Method not found", http.StatusNotFound, mcp.ErrorCodeMethodNotFound)
 		return

--- a/internal/mcp/storage/db.go
+++ b/internal/mcp/storage/db.go
@@ -88,6 +88,7 @@ func (s *DBStore) Create(_ context.Context, server *config.MCPConfig) error {
 					"routers":     model.Routers,
 					"servers":     model.Servers,
 					"tools":       model.Tools,
+					"prompts":     model.Prompts,
 					"mcp_servers": model.McpServers,
 					"updated_at":  time.Now(),
 				}).Error; err != nil {
@@ -407,6 +408,7 @@ func (s *DBStore) ListVersions(ctx context.Context, tenant, name string) ([]*con
 			Routers:    v.Routers,
 			Servers:    v.Servers,
 			Tools:      v.Tools,
+			Prompts:    v.Prompts,
 			McpServers: v.McpServers,
 			IsActive:   v.Version == activeVersionMap[v.Name],
 			Hash:       v.Hash,
@@ -462,6 +464,7 @@ func (s *DBStore) SetActiveVersion(ctx context.Context, tenant, name string, ver
 			Routers:    versionModel.Routers,
 			Servers:    versionModel.Servers,
 			Tools:      versionModel.Tools,
+			Prompts:    versionModel.Prompts,
 			McpServers: versionModel.McpServers,
 			Hash:       versionModel.Hash,
 		}
@@ -478,12 +481,13 @@ func (s *DBStore) SetActiveVersion(ctx context.Context, tenant, name string, ver
 			Routers:    versionModel.Routers,
 			Servers:    versionModel.Servers,
 			Tools:      versionModel.Tools,
+			Prompts:    versionModel.Prompts,
 			McpServers: versionModel.McpServers,
 		}
 
 		if err := tx.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "name"}, {Name: "tenant"}},
-			DoUpdates: clause.AssignmentColumns([]string{"updated_at", "routers", "servers", "tools", "mcp_servers", "deleted_at"}),
+			DoUpdates: clause.AssignmentColumns([]string{"updated_at", "routers", "servers", "tools", "prompts", "mcp_servers", "deleted_at"}),
 		}).Create(mcpConfig).Error; err != nil {
 			return err
 		}

--- a/internal/mcp/storage/model.go
+++ b/internal/mcp/storage/model.go
@@ -22,6 +22,7 @@ type MCPConfig struct {
 	Routers    string         `gorm:"type:text; column:routers"`
 	Servers    string         `gorm:"type:text; column:servers"`
 	Tools      string         `gorm:"type:text; column:tools"`
+	Prompts    string         `gorm:"type:text; column:prompts"`
 	McpServers string         `gorm:"type:text; column:mcp_servers"`
 	DeletedAt  gorm.DeletedAt `gorm:"index"`
 }
@@ -47,6 +48,11 @@ func (m *MCPConfig) ToMCPConfig() (*config.MCPConfig, error) {
 	}
 	if len(m.Tools) > 0 {
 		if err := json.Unmarshal([]byte(m.Tools), &cfg.Tools); err != nil {
+			return nil, err
+		}
+	}
+	if len(m.Prompts) > 0 {
+		if err := json.Unmarshal([]byte(m.Prompts), &cfg.Prompts); err != nil {
 			return nil, err
 		}
 	}
@@ -76,6 +82,11 @@ func FromMCPConfig(cfg *config.MCPConfig) (*MCPConfig, error) {
 		return nil, err
 	}
 
+	prompts, err := json.Marshal(cfg.Prompts)
+	if err != nil {
+		return nil, err
+	}
+	
 	mcpServers, err := json.Marshal(cfg.McpServers)
 	if err != nil {
 		return nil, err
@@ -89,6 +100,7 @@ func FromMCPConfig(cfg *config.MCPConfig) (*MCPConfig, error) {
 		Routers:    string(routers),
 		Servers:    string(servers),
 		Tools:      string(tools),
+		Prompts:    string(prompts),
 		McpServers: string(mcpServers),
 	}, nil
 }
@@ -133,6 +145,7 @@ type MCPConfigVersion struct {
 	Routers    string          `gorm:"type:text;column:routers"`
 	Servers    string          `gorm:"type:text;column:servers"`
 	Tools      string          `gorm:"type:text;column:tools"`
+	Prompts    string         `gorm:"type:text; column:prompts"`
 	McpServers string          `gorm:"type:text;column:mcp_servers"`
 	Hash       string          `gorm:"column:hash;not null"` // hash of the configuration content
 	DeletedAt  gorm.DeletedAt  `gorm:"index"`
@@ -162,6 +175,11 @@ func (m *MCPConfigVersion) ToMCPConfig() (*config.MCPConfig, error) {
 			return nil, err
 		}
 	}
+	if len(m.Prompts) > 0 {
+		if err := json.Unmarshal([]byte(m.Prompts), &cfg.Prompts); err != nil {
+			return nil, err
+		}
+	}	
 	if len(m.McpServers) > 0 {
 		if err := json.Unmarshal([]byte(m.McpServers), &cfg.McpServers); err != nil {
 			return nil, err
@@ -183,6 +201,9 @@ func FromMCPConfigVersion(cfg *config.MCPConfig, version int, createdBy string, 
 	if cfg.Tools == nil {
 		cfg.Tools = []config.ToolConfig{}
 	}
+	if cfg.Prompts == nil {
+		cfg.Prompts = []config.PromptConfig{}
+	}	
 	if cfg.McpServers == nil {
 		cfg.McpServers = []config.MCPServerConfig{}
 	}
@@ -202,13 +223,18 @@ func FromMCPConfigVersion(cfg *config.MCPConfig, version int, createdBy string, 
 		return nil, err
 	}
 
+	prompts, err := json.Marshal(cfg.Prompts)
+	if err != nil {
+		return nil, err
+	}
+
 	mcpServers, err := json.Marshal(cfg.McpServers)
 	if err != nil {
 		return nil, err
 	}
 
 	// Calculate hash of the configuration content
-	content := fmt.Sprintf("%s%s%s%s", routers, servers, tools, mcpServers)
+	content := fmt.Sprintf("%s%s%s%s", routers, servers, tools, prompts, mcpServers)
 	hash := sha256.Sum256([]byte(content))
 
 	return &MCPConfigVersion{
@@ -221,6 +247,7 @@ func FromMCPConfigVersion(cfg *config.MCPConfig, version int, createdBy string, 
 		Routers:    string(routers),
 		Servers:    string(servers),
 		Tools:      string(tools),
+		Prompts:    string(prompts),
 		McpServers: string(mcpServers),
 		Hash:       hex.EncodeToString(hash[:]),
 	}, nil
@@ -237,6 +264,7 @@ func (m *MCPConfigVersion) ToConfigVersion() *config.MCPConfigVersion {
 		Routers:    m.Routers,
 		Servers:    m.Servers,
 		Tools:      m.Tools,
+		Prompts:    m.Prompts,
 		McpServers: m.McpServers,
 		Hash:       m.Hash,
 	}

--- a/pkg/mcp/cnst.go
+++ b/pkg/mcp/cnst.go
@@ -15,6 +15,8 @@ const (
 	Ping                    = "ping"
 	ToolsList               = "tools/list"
 	ToolsCall               = "tools/call"
+	PromptsList             = "prompts/list"
+	PromptsGet              = "prompts/get"		
 )
 
 // Response
@@ -33,8 +35,6 @@ const (
 	SamplingCreateMessage = "sampling/createMessage"
 	LoggingSetLevel       = "logging/setLevel"
 
-	PromptsGet             = "prompts/get"
-	PromptsList            = "prompts/list"
 	ResourcesList          = "resources/list"
 	ResourcesTemplatesList = "resources/templates/list"
 	ResourcesRead          = "resources/read"

--- a/pkg/mcp/server_types.go
+++ b/pkg/mcp/server_types.go
@@ -222,6 +222,31 @@ type (
 		// Additional information about the error
 		Data any `json:"data,omitempty"`
 	}
+
+	// PromptSchema and related types
+
+	PromptSchema struct {
+		Name        string                 `json:"name" yaml:"name"`
+		Description string                 `json:"description" yaml:"description"`
+		Arguments   []PromptArgumentSchema `json:"arguments" yaml:"arguments"`
+		PromptResponse []PromptResponseSchema `json:"promptResponse,omitempty" yaml:"promptResponse,omitempty"`
+	}
+
+	PromptArgumentSchema struct {
+		Name        string `json:"name" yaml:"name"`
+		Description string `json:"description" yaml:"description"`
+		Required    bool   `json:"required" yaml:"required"`
+	}
+
+	PromptResponseSchema struct {
+		Role    string                `json:"role" yaml:"role"`
+		Content PromptResponseContentSchema `json:"content" yaml:"content"`
+	}
+
+	PromptResponseContentSchema struct {
+		Type string `json:"type" yaml:"type"`
+		Text string `json:"text" yaml:"text"`
+	}	
 )
 
 // NewInitializeRequest creates a new initialize request
@@ -346,3 +371,4 @@ func NewCallToolResultError(text string) *CallToolResult {
 		IsError: true,
 	}
 }
+

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -294,7 +294,20 @@
     "server_name_limit": "{{count}}/{{max}} characters",
     "name_length_error": "Name length cannot exceed 50 characters",
     "sse_prefix": "SSE Prefix",
-    "sse_prefix_placeholder": "Enter SSE prefix"
+    "sse_prefix_placeholder": "Enter SSE prefix",
+    "prompt": "Prompt",
+    "prompts": "Prompts",    
+    "prompt_name": "Prompt Name",
+    "arguments": "Arguments",
+    "required": "Required",
+    "remove_prompt": "Remove Prompt",
+    "add_prompt": "Add Prompt",
+    "prompt_response": "Prompt Response",
+    "add_prompt_response": "Add Response",
+    "prompt_response_role": "Role",
+    "prompt_response_type": "Content Type",
+    "prompt_response_text": "Text",
+    "remove_prompt_response": "Remove Response"
   },
   "chat": {
     "title": "Chat",

--- a/web/src/i18n/locales/zh/translation.json
+++ b/web/src/i18n/locales/zh/translation.json
@@ -296,7 +296,20 @@
     "direct_to_mcp_gateway": "直接访问MCP Gateway(5235):",
     "name_length_error": "名称长度不能超过50个字符",
     "sse_prefix": "SSE 前缀",
-    "sse_prefix_placeholder": "请输入 SSE 前缀"
+    "sse_prefix_placeholder": "请输入 SSE 前缀",
+    "prompt": "提示词",
+    "prompts": "提示词",     
+    "prompt_name": "提示词名称",
+    "arguments": "参数",
+    "required": "必填",
+    "remove_prompt": "删除提示词",
+    "add_prompt": "添加提示词",
+    "prompt_response": "提示词对话",
+    "add_prompt_response": "添加对话",
+    "prompt_response_role": "角色",
+    "prompt_response_type": "内容类型",
+    "prompt_response_text": "文本内容",
+    "remove_prompt_response": "删除对话"
   },
   "chat": {
     "title": "聊天",

--- a/web/src/pages/gateway/components/ConfigEditor.tsx
+++ b/web/src/pages/gateway/components/ConfigEditor.tsx
@@ -12,6 +12,7 @@ import {MCPServersConfig} from './MCPServersConfig';
 import {RouterConfig} from './RouterConfig';
 import {ServersConfig} from './ServersConfig';
 import {ToolsConfig} from './ToolsConfig';
+import {PromptsConfig} from './PromptsConfig';
 
 export function ConfigEditor({ config, onChange, isDark, editorOptions, isEditing }: ConfigEditorProps) {
   const { t } = useTranslation();
@@ -185,6 +186,12 @@ export function ConfigEditor({ config, onChange, isDark, editorOptions, isEditin
                 updateConfig={updateConfig}
                 tenants={tenants}
               />
+            </Tab>
+            <Tab key="prompts" title={t('gateway.prompts')}>
+              <PromptsConfig
+                parsedConfig={parsedConfig || defaultConfig}
+                updateConfig={updateConfig}
+              />              
             </Tab>
           </Tabs>
         </div>

--- a/web/src/pages/gateway/components/PromptsConfig.tsx
+++ b/web/src/pages/gateway/components/PromptsConfig.tsx
@@ -1,0 +1,254 @@
+import { Input, Button, Checkbox, Accordion, AccordionItem, Textarea } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import { useTranslation } from 'react-i18next';
+
+import { Gateway } from '../../../types/gateway';
+
+interface PromptArgument {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+interface PromptsConfigProps {
+  parsedConfig: Gateway;
+  updateConfig: (newData: Partial<Gateway>) => void;
+}
+
+export function PromptsConfig({
+  parsedConfig,
+  updateConfig
+}: PromptsConfigProps) {
+  const { t } = useTranslation();
+  const prompts = parsedConfig?.prompts || [];
+
+  // Update a prompt at a given index
+  const updatePrompt = (index: number, field: string, value: any) => {
+    const updatedPrompts = [...prompts];
+    updatedPrompts[index] = {
+      ...updatedPrompts[index],
+      [field]: value
+    };
+    updateConfig({ prompts: updatedPrompts });
+  };
+
+  // Update an argument for a prompt at a given index
+  const updateArgument = (promptIndex: number, argIndex: number, field: keyof PromptArgument, value: string | boolean) => {
+    const updatedPrompts = [...prompts];
+    const updatedArgs = [...(updatedPrompts[promptIndex]?.arguments || [])];
+    updatedArgs[argIndex] = { ...updatedArgs[argIndex], [field]: value };
+    updatedPrompts[promptIndex] = {
+      ...updatedPrompts[promptIndex],
+      arguments: updatedArgs
+    };
+    updateConfig({ prompts: updatedPrompts });
+  };
+
+  const addArgument = (promptIndex: number) => {
+    const updatedPrompts = [...prompts];
+    const updatedArgs = [...(updatedPrompts[promptIndex]?.arguments || [])];
+    updatedArgs.push({ name: "", description: "", required: false });
+    updatedPrompts[promptIndex] = {
+      ...updatedPrompts[promptIndex],
+      arguments: updatedArgs
+    };
+    updateConfig({ prompts: updatedPrompts });
+  };
+
+  const removeArgument = (promptIndex: number, argIndex: number) => {
+    const updatedPrompts = [...prompts];
+    const updatedArgs = [...(updatedPrompts[promptIndex]?.arguments || [])];
+    updatedArgs.splice(argIndex, 1);
+    updatedPrompts[promptIndex] = {
+      ...updatedPrompts[promptIndex],
+      arguments: updatedArgs
+    };
+    updateConfig({ prompts: updatedPrompts });
+  };
+
+  // Add a new prompt
+  const addPrompt = () => {
+    const updatedPrompts = [
+      ...prompts,
+      { name: '', description: '', arguments: [] }
+    ];
+    updateConfig({ prompts: updatedPrompts });
+  };
+
+  // Remove a prompt
+  const removePrompt = (index: number) => {
+    const updatedPrompts = [...prompts];
+    updatedPrompts.splice(index, 1);
+    updateConfig({ prompts: updatedPrompts });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Accordion variant="splitted">
+        {prompts.map((prompt, promptIdx) => (
+          <AccordionItem
+            key={promptIdx}
+            title={prompt.name || t('gateway.prompt') || 'Prompt'}
+            subtitle={prompt.description}
+            startContent={<Icon icon="lucide:message-square" className="text-primary-500" />}
+          >
+            <div className="p-2 space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Input
+                  label={t('gateway.prompt_name') || 'Prompt Name'}
+                  value={prompt.name}
+                  onChange={e => updatePrompt(promptIdx, 'name', e.target.value)}
+                />
+                <Input
+                  label={t('gateway.description') || 'Description'}
+                  value={prompt.description}
+                  onChange={e => updatePrompt(promptIdx, 'description', e.target.value)}
+                />
+              </div>
+              <div className="bg-content1 p-4 rounded-medium border border-content2">
+                <div className="flex justify-between items-center mb-3">
+                  <h4 className="text-md font-medium">{t('gateway.arguments') || 'Arguments'}</h4>
+                  <Button
+                    size="sm"
+                    color="primary"
+                    variant="flat"
+                    startContent={<Icon icon="lucide:plus" />}
+                    onPress={() => addArgument(promptIdx)}
+                  >
+                    {t('gateway.add_argument') || 'Add Argument'}
+                  </Button>
+                </div>
+                {prompt.arguments && prompt.arguments.map((arg, argIdx) => (
+                  <div key={argIdx} className="grid grid-cols-1 md:grid-cols-4 gap-2 mb-2 items-center">
+                    <Input
+                      label={t('gateway.argument_name') || 'Name'}
+                      value={arg.name}
+                      onChange={e => updateArgument(promptIdx, argIdx, 'name', e.target.value)}
+                    />
+                    <Input
+                      label={t('gateway.argument_description') || 'Description'}
+                      value={arg.description}
+                      onChange={e => updateArgument(promptIdx, argIdx, 'description', e.target.value)}
+                    />
+                    <Checkbox
+                      isSelected={arg.required}
+                      onChange={e => updateArgument(promptIdx, argIdx, 'required', e.target.checked)}
+                    >
+                      {t('gateway.required') || 'Required'}
+                    </Checkbox>
+                    <Button
+                      color="danger"
+                      variant="flat"
+                      size="sm"
+                      startContent={<Icon icon="lucide:trash-2" />}
+                      onPress={() => removeArgument(promptIdx, argIdx)}
+                    >
+                      {t('gateway.remove_argument') || 'Remove'}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              {/* Prompt Response Section */}
+              <div className="bg-content1 p-4 rounded-medium border border-content2 mt-4">
+                <div className="flex justify-between items-center mb-3">
+                  <h4 className="text-md font-medium">{t('gateway.prompt_response') || 'Prompt Response'}</h4>
+                  <Button
+                    size="sm"
+                    color="primary"
+                    variant="flat"
+                    startContent={<Icon icon="lucide:plus" />}
+                    onPress={() => {
+                      const updatedPrompts = [...prompts];
+                      const promptResponse = updatedPrompts[promptIdx].promptResponse || [];
+                      promptResponse.push({ role: '', content: { type: 'text', text: '' } });
+                      updatedPrompts[promptIdx] = { ...updatedPrompts[promptIdx], promptResponse };
+                      updateConfig({ prompts: updatedPrompts });
+                    }}
+                  >
+                    {t('gateway.add_prompt_response') || 'Add Response'}
+                  </Button>
+                </div>
+                {prompt.promptResponse && prompt.promptResponse.map((ret, retIdx) => (
+                  <div key={retIdx} className="grid grid-cols-1 md:grid-cols-5 gap-2 mb-2 items-center">
+                    <Input
+                      label={t('gateway.prompt_response_role') || 'Role'}
+                      value={ret.role}
+                      onChange={e => {
+                        const updatedPrompts = [...prompts];
+                        const promptResponse = [...(updatedPrompts[promptIdx].promptResponse || [])];
+                        promptResponse[retIdx] = { ...promptResponse[retIdx], role: e.target.value };
+                        updatedPrompts[promptIdx] = { ...updatedPrompts[promptIdx], promptResponse };
+                        updateConfig({ prompts: updatedPrompts });
+                      }}
+                    />
+                    <Input
+                      label={t('gateway.prompt_response_type') || 'Content Type'}
+                      value={ret.content.type}
+                      onChange={e => {
+                        const updatedPrompts = [...prompts];
+                        const promptResponse = [...(updatedPrompts[promptIdx].promptResponse || [])];
+                        promptResponse[retIdx] = { ...promptResponse[retIdx], content: { ...promptResponse[retIdx].content, type: e.target.value } };
+                        updatedPrompts[promptIdx] = { ...updatedPrompts[promptIdx], promptResponse };
+                        updateConfig({ prompts: updatedPrompts });
+                      }}
+                    />
+                    <Textarea
+                      label={t('gateway.prompt_response_text') || 'Text'}
+                      value={ret.content.text}
+                      minRows={3}
+                      maxRows={8}
+                      className="col-span-2"
+                      onChange={e => {
+                        const updatedPrompts = [...prompts];
+                        const promptResponse = [...(updatedPrompts[promptIdx].promptResponse || [])];
+                        promptResponse[retIdx] = { ...promptResponse[retIdx], content: { ...promptResponse[retIdx].content, text: e.target.value } };
+                        updatedPrompts[promptIdx] = { ...updatedPrompts[promptIdx], promptResponse };
+                        updateConfig({ prompts: updatedPrompts });
+                      }}
+                    />
+                    <Button
+                      color="danger"
+                      variant="flat"
+                      size="sm"
+                      startContent={<Icon icon="lucide:trash-2" />}
+                      onPress={() => {
+                        const updatedPrompts = [...prompts];
+                        const promptResponse = [...(updatedPrompts[promptIdx].promptResponse || [])];
+                        promptResponse.splice(retIdx, 1);
+                        updatedPrompts[promptIdx] = { ...updatedPrompts[promptIdx], promptResponse };
+                        updateConfig({ prompts: updatedPrompts });
+                      }}
+                    >
+                      {t('gateway.remove_prompt_response') || 'Remove'}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+              <div className="flex justify-end mt-2">
+                <Button
+                  color="danger"
+                  variant="flat"
+                  size="sm"
+                  startContent={<Icon icon="lucide:trash-2" />}
+                  onPress={() => removePrompt(promptIdx)}
+                >
+                  {t('gateway.remove_prompt') || 'Remove Prompt'}
+                </Button>
+              </div>
+            </div>
+          </AccordionItem>
+        ))}
+      </Accordion>
+      <div className="flex justify-center">
+        <Button
+          color="primary"
+          variant="flat"
+          startContent={<Icon icon="lucide:plus" />}
+          onPress={addPrompt}
+        >
+          {t('gateway.add_prompt') || 'Add Prompt'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/gateway/constants/defaultConfig.ts
+++ b/web/src/pages/gateway/constants/defaultConfig.ts
@@ -7,6 +7,7 @@ export const defaultConfig: Gateway = {
   routers: [],
   servers: [],
   tools: [],
+  prompts: [],
   mcpServers: [],
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString()

--- a/web/src/pages/gateway/gateway-manager.tsx
+++ b/web/src/pages/gateway/gateway-manager.tsx
@@ -81,7 +81,7 @@ export function GatewayManager() {
   const [tenants, setTenants] = React.useState<Tenant[]>([]);
   const [selectedTenants, setSelectedTenants] = React.useState<Tenant[]>([]);
   const [tenantInputValue, setTenantInputValue] = React.useState('');
-  const [viewMode, setViewMode] = React.useState<string>('card');
+  const [viewMode, setViewMode] = React.useState<string>('table');
   const [isDark, setIsDark] = React.useState(() => {
     return document.documentElement.classList.contains('dark');
   });

--- a/web/src/types/gateway.ts
+++ b/web/src/types/gateway.ts
@@ -1,3 +1,5 @@
+import type { PromptConfig } from './prompt';
+
 export interface Tenant {
   id: number;
   name: string;
@@ -19,6 +21,7 @@ export interface Gateway {
   tenant: string;
   mcpServers?: MCPServerConfig[];
   tools?: ToolConfig[];
+  prompts?: PromptConfig[];
   servers?: ServerConfig[];
   routers?: RouterConfig[];
   createdAt: string;

--- a/web/src/types/prompt.ts
+++ b/web/src/types/prompt.ts
@@ -1,0 +1,23 @@
+
+export interface PromptArgument {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+export interface PromptResponseContent {
+  type: string;
+  text: string;
+}
+
+export interface PromptResponse {
+  role: string;
+  content: PromptResponseContent;
+}
+
+export interface PromptConfig {
+  name: string;
+  description: string;
+  arguments?: PromptArgument[];
+  promptResponse?: PromptResponse[];
+}


### PR DESCRIPTION
Add MCP Prompt Support - https://github.com/AmoyLab/Unla/issues/148
Default tenant prefix bug "/tenant" t0 "tenant" convertor.go - https://github.com/AmoyLab/Unla/issues/120
Default Table View - gateway-manager.tsx - 
Multi Docker fix mcp gateway in nginx config - deploy\docker\multi\web\nginx.conf

## Summary by Sourcery

Add full MCP prompt support through server handlers, state, storage, and web UI; fix tenant prefix conversion; default to table view in GatewayManager; and enhance multi-Docker nginx routing for the MCP gateway.

New Features:
- Introduce JSON-RPC methods prompts/list and prompts/get for retrieving prompt schemas with argument substitution
- Define PromptConfig and PromptSchema types across config, DTOs, server types, and storage for prompt persistence
- Add PromptsConfig UI component and integrate prompt management into the gateway config editor

Bug Fixes:
- Fix default tenant prefix conversion by stripping leading slash

Enhancements:
- Change default gateway manager view mode to table
- Provide stub implementations of FetchPrompts and FetchPrompt in all transport layers

Deployment:
- Update multi-Docker nginx configuration to proxy /mcp/ requests to the mcp-gateway upstream