### PR TITLE
VITE_runtime_var and mcp-protocol-version header

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -222,6 +222,8 @@ func initRouter(db database.Database, store storage.Store, ntf notifier.Notifier
 		protected.POST("/chat/messages", chatHandler.HandleSaveChatMessage)
 	}
 
+	// Public runtime config endpoint for frontend
+	r.GET("/api/runtime-config", apiserverHandler.HandleRuntimeConfig)
 
 	r.Static("/web", "./web")
 	return r

--- a/configs/mcp-gateway.yaml
+++ b/configs/mcp-gateway.yaml
@@ -94,6 +94,8 @@ auth:
       - "Content-Type"
       - "Authorization"
       - "Mcp-Session-Id"
+      - "mcp-protocol-version"      
     exposeHeaders:
       - "Mcp-Session-Id"
+      - "mcp-protocol-version"      
     allowCredentials: true

--- a/configs/proxy-mcp-exp.yaml
+++ b/configs/proxy-mcp-exp.yaml
@@ -15,8 +15,10 @@ routers:
         - "Content-Type"
         - "Authorization"
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"        
       exposeHeaders:
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"
       allowCredentials: true
   - server: "mock-user-sse"
     prefix: "/mcp/sse-proxy"
@@ -31,8 +33,10 @@ routers:
         - "Content-Type"
         - "Authorization"
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"
       exposeHeaders:
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"
       allowCredentials: true
   - server: "mock-user-mcp"
     prefix: "/mcp/streamable-http-proxy"
@@ -47,8 +51,10 @@ routers:
         - "Content-Type"
         - "Authorization"
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"
       exposeHeaders:
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"
       allowCredentials: true
 
 mcpServers:

--- a/configs/proxy-mock-server.yaml
+++ b/configs/proxy-mock-server.yaml
@@ -16,8 +16,10 @@ routers:
         - "Content-Type"
         - "Authorization"
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"
       exposeHeaders:
         - "Mcp-Session-Id"
+        - "mcp-protocol-version"
       allowCredentials: true
 
 servers:

--- a/deploy/docker/multi/web/Dockerfile
+++ b/deploy/docker/multi/web/Dockerfile
@@ -16,16 +16,6 @@ RUN GOOS=linux go build -o apiserver ./cmd/apiserver
 
 FROM node:20.18.0 AS web-builder
 
-ARG VITE_API_BASE_URL=/api
-ARG VITE_WS_BASE_URL=/ws
-ARG VITE_MCP_GATEWAY_BASE_URL=/mcp
-ARG VITE_BASE_URL=/
-
-ENV VITE_API_BASE_URL=${VITE_API_BASE_URL} \
-    VITE_WS_BASE_URL=${VITE_WS_BASE_URL} \
-    VITE_MCP_GATEWAY_BASE_URL=${VITE_MCP_GATEWAY_BASE_URL} \
-    VITE_BASE_URL=${VITE_BASE_URL}
-
 WORKDIR /app/web
 
 COPY web/package*.json ./

--- a/internal/apiserver/handler/runtime_config.go
+++ b/internal/apiserver/handler/runtime_config.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+// HandleRuntimeConfig serves frontend runtime config as JSON
+func HandleRuntimeConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"VITE_API_BASE_URL":         os.Getenv("VITE_API_BASE_URL"),
+		"VITE_WS_BASE_URL":          os.Getenv("VITE_WS_BASE_URL"),
+		"VITE_MCP_GATEWAY_BASE_URL": os.Getenv("VITE_MCP_GATEWAY_BASE_URL"),
+		"VITE_BASE_URL":             os.Getenv("VITE_BASE_URL"),
+	})
+}

--- a/internal/apiserver/handler/runtime_config.go
+++ b/internal/apiserver/handler/runtime_config.go
@@ -3,16 +3,47 @@ package handler
 import (
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
 
 // HandleRuntimeConfig serves frontend runtime config as JSON
 func HandleRuntimeConfig(c *gin.Context) {
+	// Get debug mode from environment or default to false
+	debugMode := false
+	if debugModeStr := os.Getenv("DEBUG_MODE"); debugModeStr != "" {
+		if parsed, err := strconv.ParseBool(debugModeStr); err == nil {
+			debugMode = parsed
+		}
+	}
+	// Get version from environment or default to "production"
+	version := os.Getenv("APP_VERSION")
+	if version == "" {
+		version = "production"
+	}
+
+	// Check if experimental features are enabled
+	enableExperimental := false
+	if expStr := os.Getenv("ENABLE_EXPERIMENTAL"); expStr != "" {
+		if parsed, err := strconv.ParseBool(expStr); err == nil {
+			enableExperimental = parsed
+		}
+	}
+
 	c.JSON(http.StatusOK, gin.H{
+		// Keep original environment variables for backward compatibility
 		"VITE_API_BASE_URL":         os.Getenv("VITE_API_BASE_URL"),
 		"VITE_WS_BASE_URL":          os.Getenv("VITE_WS_BASE_URL"),
 		"VITE_MCP_GATEWAY_BASE_URL": os.Getenv("VITE_MCP_GATEWAY_BASE_URL"),
 		"VITE_BASE_URL":             os.Getenv("VITE_BASE_URL"),
+		
+		// Add new properties matching our TypeScript interface
+		"apiBaseUrl":                os.Getenv("VITE_API_BASE_URL"),
+		"debugMode":                 debugMode,
+		"version":                   version,
+		"features": gin.H{
+			"enableExperimental": enableExperimental,
+		},
 	})
 }

--- a/pkg/openapi/converter.go
+++ b/pkg/openapi/converter.go
@@ -102,8 +102,8 @@ func (c *Converter) Convert(specData []byte) (*config.MCPConfig, error) {
 		CORS: &config.CORSConfig{
 			AllowOrigins:     []string{"*"},
 			AllowMethods:     []string{"GET", "POST", "OPTIONS"},
-			AllowHeaders:     []string{"Content-Type", "Authorization", "Mcp-Session-Id"},
-			ExposeHeaders:    []string{"Mcp-Session-Id"},
+			AllowHeaders:     []string{"Content-Type", "Authorization", "Mcp-Session-Id" ,"mcp-protocol-version"},
+			ExposeHeaders:    []string{"Mcp-Session-Id", "mcp-protocol-version"},
 			AllowCredentials: true,
 		},
 	}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,7 +59,7 @@ function MainLayout() {
 export default function App() {
   return (
     <Router 
-      basename={import.meta.env.VITE_BASE_URL}
+      basename={window.RUNTIME_CONFIG?.VITE_BASE_URL || '/'}
       future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
       <ThemeInitializer />

--- a/web/src/components/LoadingScreen.tsx
+++ b/web/src/components/LoadingScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Spinner } from "@heroui/react";
+
+export const LoadingScreen: React.FC = () => {
+  return (
+    <div className="h-screen w-full flex flex-col items-center justify-center bg-background">
+      <div className="mb-8">
+        <img src="/logo.png" alt="Logo" className="w-20 h-20" />
+      </div>
+      <Spinner size="lg" color="primary" />
+      <div className="mt-6 text-foreground/70">
+        Loading application...
+      </div>
+    </div>
+  );
+};

--- a/web/src/env.d.ts
+++ b/web/src/env.d.ts
@@ -1,11 +1,21 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_MCP_GATEWAY_BASE_URL: string
-  readonly  VITE_API_BASE_URL: string
-  readonly VITE_WS_BASE_URL: string
+  // Add Vite's built-in env variables
+  readonly MODE: string;
+  readonly DEV: boolean;
+  readonly PROD: boolean;
+  readonly SSR: boolean;
+  
+  // App-specific env variables
+  readonly VITE_MCP_GATEWAY_BASE_URL: string;
+  readonly VITE_API_BASE_URL: string;
+  readonly VITE_WS_BASE_URL: string;
+  
+  // Allow any other env variables to be defined
+  readonly [key: string]: string | boolean | undefined;
 }
 
 interface ImportMeta {
-  readonly env: ImportMetaEnv
+  readonly env: ImportMetaEnv;
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,7 +2,7 @@ import {HeroUIProvider, ToastProvider} from "@heroui/react";
 import { loader } from '@monaco-editor/react';
 import React from "react";
 import ReactDOM from "react-dom/client";
-
+import axios from "axios";
 import App from "./App.tsx";
 import './i18n';
 
@@ -43,13 +43,36 @@ if (savedTheme === 'dark') {
   document.documentElement.classList.remove('dark');
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <HeroUIProvider>
-      <ToastProvider placement="bottom-right" />
-      <main className="text-foreground bg-background h-screen overflow-hidden">
-        <App />
-      </main>
-    </HeroUIProvider>
-  </React.StrictMode>,
-);
+// Fetch runtime config before rendering the app
+const fetchRuntimeConfig = async () => {
+  console.log("[RUNTIME_CONFIG] Fetching /api/runtime-config...");
+  try {
+    const response = await axios.get("/api/runtime-config");
+    console.log("[RUNTIME_CONFIG] Fetched config:", response.data);
+    window.RUNTIME_CONFIG = response.data;
+  } catch (error) {
+    console.error("[RUNTIME_CONFIG] Failed to load runtime config:", error);
+    window.RUNTIME_CONFIG = {};
+  }
+
+  console.log("[RUNTIME_CONFIG] Rendering React app...");
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <HeroUIProvider>
+        <ToastProvider placement="bottom-right" />
+        <main className="text-foreground bg-background h-screen overflow-hidden">
+          <App />
+        </main>
+      </HeroUIProvider>
+    </React.StrictMode>,
+  );
+};
+
+fetchRuntimeConfig();
+
+// Add global declaration for RUNTIME_CONFIG
+declare global {
+  interface Window {
+    RUNTIME_CONFIG: any;
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,10 @@
-import {HeroUIProvider, ToastProvider} from "@heroui/react";
+import { HeroUIProvider, ToastProvider } from "@heroui/react";
 import { loader } from '@monaco-editor/react';
 import React from "react";
 import ReactDOM from "react-dom/client";
 import axios from "axios";
 import App from "./App.tsx";
+import { LoadingScreen } from "./components/LoadingScreen";
 import './i18n';
 
 import "./index.css";
@@ -43,36 +44,95 @@ if (savedTheme === 'dark') {
   document.documentElement.classList.remove('dark');
 }
 
-// Fetch runtime config before rendering the app
-const fetchRuntimeConfig = async () => {
-  console.log("[RUNTIME_CONFIG] Fetching /api/runtime-config...");
-  try {
-    const response = await axios.get("/api/runtime-config");
-    console.log("[RUNTIME_CONFIG] Fetched config:", response.data);
-    window.RUNTIME_CONFIG = response.data;
-  } catch (error) {
-    console.error("[RUNTIME_CONFIG] Failed to load runtime config:", error);
-    window.RUNTIME_CONFIG = {};
-  }
-
-  console.log("[RUNTIME_CONFIG] Rendering React app...");
-  ReactDOM.createRoot(document.getElementById("root")!).render(
+// Show loading screen immediately
+const rootElement = document.getElementById("root");
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(
     <React.StrictMode>
       <HeroUIProvider>
-        <ToastProvider placement="bottom-right" />
-        <main className="text-foreground bg-background h-screen overflow-hidden">
-          <App />
-        </main>
+        <LoadingScreen />
       </HeroUIProvider>
-    </React.StrictMode>,
+    </React.StrictMode>
   );
+}
+
+// Define proper types for RUNTIME_CONFIG
+export interface RuntimeConfig {
+  apiBaseUrl: string;
+  debugMode: boolean;
+  version: string;
+  features: {
+    enableExperimental: boolean;
+    [key: string]: boolean;
+  };
+  [key: string]: any; // For any additional properties
+}
+
+// Provide defaults for runtime config
+const defaultRuntimeConfig: RuntimeConfig = {
+  apiBaseUrl: '',
+  debugMode: false,
+  version: '0.0.0',
+  features: {
+    enableExperimental: false
+  }
 };
 
-fetchRuntimeConfig();
-
-// Add global declaration for RUNTIME_CONFIG
 declare global {
   interface Window {
-    RUNTIME_CONFIG: any;
+    RUNTIME_CONFIG: RuntimeConfig;
   }
 }
+
+// Fetch runtime config before rendering the app
+const fetchRuntimeConfig = async () => {
+  // Only log in development mode
+  const isDev = import.meta.env.DEV;
+  
+  try {
+    isDev && console.log("[RUNTIME_CONFIG] Fetching /api/runtime-config...");
+    const response = await axios.get<RuntimeConfig>("/api/runtime-config");
+    isDev && console.log("[RUNTIME_CONFIG] Fetched config:", response.data);
+    
+    // Merge with defaults to ensure all properties exist
+    window.RUNTIME_CONFIG = {
+      ...defaultRuntimeConfig,
+      ...response.data,
+      // Deep merge for nested objects
+      features: {
+        ...defaultRuntimeConfig.features,
+        ...(response.data.features || {})
+      }
+    };
+  } catch (error) {
+    // Always log errors, but with conditional detail level
+    console.error(
+      "[RUNTIME_CONFIG] Failed to load runtime config", 
+      isDev ? error : ''
+    );
+    
+    // Use defaults on error
+    window.RUNTIME_CONFIG = { ...defaultRuntimeConfig };
+  }
+  // Render the main application
+  isDev && console.log("[RUNTIME_CONFIG] Rendering React app...");
+  
+  const rootElement = document.getElementById("root");
+  if (rootElement) {
+    ReactDOM.createRoot(rootElement).render(
+      <React.StrictMode>
+        <HeroUIProvider>
+          <ToastProvider placement="bottom-right" />
+          <main className="text-foreground bg-background h-screen overflow-hidden">
+            <App />
+          </main>
+        </HeroUIProvider>
+      </React.StrictMode>
+    );
+  } else {
+    console.error("[RUNTIME_CONFIG] Root element not found");
+  }
+};
+
+// Start loading the runtime configuration
+fetchRuntimeConfig();

--- a/web/src/pages/gateway/components/RouterConfig.tsx
+++ b/web/src/pages/gateway/components/RouterConfig.tsx
@@ -180,6 +180,7 @@ export function RouterConfig({
             <option value="Accept" />
             <option value="Origin" />
             <option value="Mcp-Session-Id" />
+            <option value="mcp-protocol-version" />
           </datalist>
         </div>
 
@@ -226,6 +227,7 @@ export function RouterConfig({
           <datalist id={`common-expose-headers-${index}`}>
             <option value="Content-Length" />
             <option value="Mcp-Session-Id" />
+            <option value="mcp-protocol-version" />			
             <option value="X-Rate-Limit" />
           </datalist>
         </div>
@@ -317,8 +319,8 @@ export function RouterConfig({
                               cors: {
                                 allowOrigins: ['*'],
                                 allowMethods: ['GET', 'POST', 'PUT', 'OPTIONS'],
-                                allowHeaders: ['Content-Type', 'Authorization', 'Mcp-Session-Id'],
-                                exposeHeaders: ['Mcp-Session-Id'],
+                                allowHeaders: ['Content-Type', 'Authorization', 'Mcp-Session-Id', 'mcp-protocol-version' ],
+                                exposeHeaders: ['Mcp-Session-Id' ,'mcp-protocol-version'],
                                 allowCredentials: true
                               }
                             } : r

--- a/web/src/pages/gateway/gateway-manager.tsx
+++ b/web/src/pages/gateway/gateway-manager.tsx
@@ -68,6 +68,16 @@ declare global {
   }
 }
 
+// @ts-ignore
+const RUNTIME_CONFIG = window.RUNTIME_CONFIG || {};
+
+// Helper to get the gateway base URL
+const getGatewayBaseUrl = () => {
+  const base = RUNTIME_CONFIG.VITE_MCP_GATEWAY_BASE_URL;
+  if (!base) return '';
+  return base.startsWith('http') ? base : `${window.location.origin}${base}`;
+};
+
 export function GatewayManager() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -82,7 +92,7 @@ export function GatewayManager() {
   const [tenants, setTenants] = React.useState<Tenant[]>([]);
   const [selectedTenants, setSelectedTenants] = React.useState<Tenant[]>([]);
   const [tenantInputValue, setTenantInputValue] = React.useState('');
-  const [viewMode, setViewMode] = React.useState<string>('card');
+  const [viewMode, setViewMode] = React.useState<string>('table');
   const [isDark, setIsDark] = React.useState(() => {
     return document.documentElement.classList.contains('dark');
   });
@@ -686,14 +696,14 @@ export function GatewayManager() {
                                               <div className="flex items-center gap-2">
                                                 <span className="text-xs text-default-500">SSE:</span>
                                                 <code className="text-xs bg-default-100 px-1 py-1 rounded flex-1 break-all">
-                                                  {`${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/sse`}
+                                                  {`${getGatewayBaseUrl()}${router.prefix}/sse`}
                                                 </code>
                                                 <Button
                                                   isIconOnly
                                                   size="sm"
                                                   variant="light"
                                                   onPress={() => handleCopyWithIcon(
-                                                    `${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/sse`,
+                                                    `${getGatewayBaseUrl()}${router.prefix}/sse`,
                                                     `nginx-sse-${server.name}-${idx}`
                                                   )}
                                                 >
@@ -703,14 +713,14 @@ export function GatewayManager() {
                                               <div className="flex items-center gap-2">
                                                 <span className="text-xs text-default-500">Streamable HTTP:</span>
                                                 <code className="text-xs bg-default-100 px-1 py-1 rounded flex-1 break-all">
-                                                  {`${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/mcp`}
+                                                  {`${getGatewayBaseUrl()}${router.prefix}/mcp`}
                                                 </code>
                                                 <Button
                                                   isIconOnly
                                                   size="sm"
                                                   variant="light"
                                                   onPress={() => handleCopyWithIcon(
-                                                    `${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/mcp`,
+                                                    `${getGatewayBaseUrl()}${router.prefix}/mcp`,
                                                     `nginx-mcp-${server.name}-${idx}`
                                                   )}
                                                 >
@@ -894,14 +904,14 @@ export function GatewayManager() {
                                               <div className="flex items-center gap-2">
                                                 <span className="text-xs text-default-500">SSE:</span>
                                                 <code className="text-xs bg-default-100 px-1 py-1 rounded flex-1 break-all">
-                                                  {`${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/sse`}
+                                                  {`${getGatewayBaseUrl()}${router.prefix}/sse`}
                                                 </code>
                                                 <Button
                                                   isIconOnly
                                                   size="sm"
                                                   variant="light"
                                                   onPress={() => handleCopyWithIcon(
-                                                    `${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/sse`,
+                                                    `${getGatewayBaseUrl()}${router.prefix}/sse`,
                                                     `nginx-sse-${server.name}-${idx}`
                                                   )}
                                                 >
@@ -911,14 +921,14 @@ export function GatewayManager() {
                                               <div className="flex items-center gap-2">
                                                 <span className="text-xs text-default-500">Streamable HTTP:</span>
                                                 <code className="text-xs bg-default-100 px-1 py-1 rounded flex-1 break-all">
-                                                  {`${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/mcp`}
+                                                  {`${getGatewayBaseUrl()}${router.prefix}/mcp`}
                                                 </code>
                                                 <Button
                                                   isIconOnly
                                                   size="sm"
                                                   variant="light"
                                                   onPress={() => handleCopyWithIcon(
-                                                    `${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/mcp`,
+                                                    `${getGatewayBaseUrl()}${router.prefix}/mcp`,
                                                     `nginx-mcp-${server.name}-${idx}`
                                                   )}
                                                 >
@@ -1250,14 +1260,14 @@ export function GatewayManager() {
                                     <div className="flex items-center gap-2">
                                       <span className="text-xs text-default-500">SSE:</span>
                                       <code className="text-xs bg-default-100 px-1 py-1 rounded flex-1 break-all">
-                                        {`${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/sse`}
+                                        {`${getGatewayBaseUrl()}${router.prefix}/sse`}
                                       </code>
                                       <Button
                                         isIconOnly
                                         size="sm"
                                         variant="light"
                                         onPress={() => handleCopyWithIcon(
-                                          `${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/sse`,
+                                          `${getGatewayBaseUrl()}${router.prefix}/sse`,
                                           `nginx-sse-${currentModalServer?.name}-${idx}`
                                         )}
                                       >
@@ -1267,14 +1277,14 @@ export function GatewayManager() {
                                     <div className="flex items-center gap-2">
                                       <span className="text-xs text-default-500">Streamable HTTP:</span>
                                       <code className="text-xs bg-default-100 px-1 py-1 rounded flex-1 break-all">
-                                        {`${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/mcp`}
+                                        {`${getGatewayBaseUrl()}${router.prefix}/mcp`}
                                       </code>
                                       <Button
                                         isIconOnly
                                         size="sm"
                                         variant="light"
                                         onPress={() => handleCopyWithIcon(
-                                          `${import.meta.env.VITE_MCP_GATEWAY_BASE_URL?.startsWith('http') ? import.meta.env.VITE_MCP_GATEWAY_BASE_URL : `${window.location.origin}${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}`}${router.prefix}/mcp`,
+                                          `${getGatewayBaseUrl()}${router.prefix}/mcp`,
                                           `nginx-mcp-${currentModalServer?.name}-${idx}`
                                         )}
                                       >

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -11,7 +11,7 @@ import {toast} from '../utils/toast';
 
 // Create an axios instance with default config
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: window.RUNTIME_CONFIG?.VITE_API_BASE_URL || '/api',	
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',

--- a/web/src/services/mcp.ts
+++ b/web/src/services/mcp.ts
@@ -52,7 +52,8 @@ class MCPService {
 
     try {
       // Create transport and client
-      const serverUrl = new URL(`${import.meta.env.VITE_MCP_GATEWAY_BASE_URL}${prefix}/mcp`, window.location.origin);
+      const gatewayBaseUrl = window.RUNTIME_CONFIG?.VITE_MCP_GATEWAY_BASE_URL || '';
+      const serverUrl = new URL(`${gatewayBaseUrl}${prefix}/mcp`, window.location.origin);
       const transport = new StreamableHTTPClientTransport(
         serverUrl,
         {

--- a/web/src/types/images.d.ts
+++ b/web/src/types/images.d.ts
@@ -1,0 +1,25 @@
+// Type declarations for static assets
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpeg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.gif' {
+  const value: string;
+  export default value;
+}

--- a/web/src/types/react-app.d.ts
+++ b/web/src/types/react-app.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="react" />
+/// <reference types="react-dom" />
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}


### PR DESCRIPTION
VITE_runtime_var and mcp-protocol-version header

## Summary by Sourcery

Fetch runtime config at app startup via /api/runtime-config and use window.RUNTIME_CONFIG for base URLs, remove build-time VITE_* injection, propagate mcp-protocol-version header in CORS and UI, refactor gateway URL logic, and update default view mode and asset typings.

New Features:
- Serve frontend runtime configuration via /api/runtime-config endpoint and expose it on window.RUNTIME_CONFIG
- Load and apply runtime config at startup to replace build-time VITE_* env usage

Enhancements:
- Use getGatewayBaseUrl helper to resolve gateway URLs from runtime config
- Change GatewayManager default view mode from 'card' to 'table'
- Add TypeScript declarations for importing image files
- Include 'mcp-protocol-version' header in CORS allow/expose lists across configs and UI components

Build:
- Remove static VITE_* environment variable ARG/ENV declarations from Docker build stage