### PR TITLE
feat(config): Automatically create directory for SQLite database

### DIFF
--- a/internal/common/config/apiserver.go
+++ b/internal/common/config/apiserver.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -52,6 +54,11 @@ func (c *DatabaseConfig) GetDSN() string {
 	case "mysql":
 		return c.getMySQLDSN()
 	case "sqlite":
+		// Ensure the directory for the SQLite database exists.
+		// If the directory cannot be created, it's a fatal error.
+		if err := os.MkdirAll(filepath.Dir(c.DBName), 0755); err != nil {
+			panic(fmt.Errorf("failed to create directory for sqlite database: %w", err))
+		}
 		return c.DBName // For SQLite, DBName is the file path
 	default:
 		return ""


### PR DESCRIPTION
https://github.com/AmoyLab/docs/blob/f4df89dc3069e78a6d7cc247494ff43806ef7a6d/docs/development/local-development.md?plain=1#L59-L61

https://github.com/AmoyLab/Unla/blob/62eb078faf7db6b97a7d316e4cec13eee2bea917/.env.example#L31

Currently, when the application is configured to use SQLite, it fails to start if the directory for the database file (e.g., data/unla.db) does not exist. The application is unable to create the database file, and the user must manually create the parent directory (data/) to resolve the issue.

To improve usability and adhere to the "fail-fast" principle, this PR enhances the database configuration logic.

Within the (c *DatabaseConfig) GetDSN() function, for the sqlite case, the application now ensures the parent directory for the database file exists by attempting to create it with os.MkdirAll. If directory creation fails (e.g., due to a permissions issue), the application will panic immediately with a descriptive error message. This prevents a more obscure error from appearing later when the database driver attempts to open the file.

## Summary by Sourcery

Enhancements:
- Automatically create the parent directory for the SQLite database file in the configuration to prevent obscure startup errors and enforce fail-fast behavior