### PR TITLE
Ability control access to LLM Config menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,3 +116,6 @@ OAUTH2_STORAGE_TYPE=memory
 OAUTH2_REDIS_ADDR=localhost:6379
 OAUTH2_REDIS_PASSWORD=
 OAUTH2_REDIS_DB=0
+
+#restric access to llm config to admin user only
+LLM_CONFIG_ADMIN_ONLY=N

--- a/internal/apiserver/handler/runtime_config.go
+++ b/internal/apiserver/handler/runtime_config.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/amoylab/unla/pkg/version"
 )
 
 // HandleRuntimeConfig serves frontend runtime config as JSON
@@ -17,11 +18,8 @@ func HandleRuntimeConfig(c *gin.Context) {
 			debugMode = parsed
 		}
 	}
-	// Get version from environment or default to "production"
-	version := os.Getenv("APP_VERSION")
-	if version == "" {
-		version = "production"
-	}
+
+	versionStr := version.Version
 
 	// Check if experimental features are enabled
 	enableExperimental := false
@@ -41,10 +39,11 @@ func HandleRuntimeConfig(c *gin.Context) {
 		// Add new properties matching our TypeScript interface
 		"apiBaseUrl":                getEnvOrDefault("VITE_API_BASE_URL", "/api"),
 		"debugMode":                 debugMode,
-		"version":                   version,
+		"version":                   versionStr,
 		"features": gin.H{
 			"enableExperimental": enableExperimental,
 		},
+		"LLM_CONFIG_ADMIN_ONLY":     getEnvOrDefault("LLM_CONFIG_ADMIN_ONLY", "N"),
 	})
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,9 +5,9 @@ import (
 )
 
 //go:embed VERSION
-var version string
+var Version string
 
 // Get returns the current version of the application
 func Get() string {
-	return version
+	return Version
 }

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -67,6 +67,11 @@ export function Layout({ children }: LayoutProps) {
     fetchUserInfo();
   }, [t]);
 
+  const llmConfigAdminOnly = window.RUNTIME_CONFIG?.LLM_CONFIG_ADMIN_ONLY;
+  const canShowLLM =
+    llmConfigAdminOnly === 'N' ||
+    (llmConfigAdminOnly === 'Y' && userInfo?.role === 'admin');
+
   const menuGroups = [
     {
       key: 'chat-ai',
@@ -78,12 +83,12 @@ export function Layout({ children }: LayoutProps) {
           icon: 'lucide:message-square',
           path: '/chat',
         },
-        {
+        ...(canShowLLM ? [{
           key: 'llm',
           label: t('nav.llm'),
           icon: 'lucide:brain',
           path: '/llm',
-        },
+        }] : []),
       ]
     },
     {
@@ -239,6 +244,9 @@ export function Layout({ children }: LayoutProps) {
               <div className="flex items-center gap-2">
                 <img src={logoImg} alt="MCP Logo" className="w-6 h-6" />
                 <span className="text-xl font-bold">Unla</span>
+                <span className="text-xs text-muted-foreground ml-1">
+                  {window.RUNTIME_CONFIG?.version || 'dev'}
+                </span>
               </div>
             )}
           </div>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -107,7 +107,9 @@ const fetchRuntimeConfig = async () => {
       features: {
         ...defaultRuntimeConfig.features,
         ...(response.data.features || {})
-      }
+      },
+      // Ensure LLM_CONFIG_ADMIN_ONLY is set to 'N' if not present
+      LLM_CONFIG_ADMIN_ONLY: typeof response.data.LLM_CONFIG_ADMIN_ONLY === 'undefined' ? 'N' : response.data.LLM_CONFIG_ADMIN_ONLY
     };
   } catch (error) {
     // Always log errors, but with conditional detail level


### PR DESCRIPTION
Ability control access to LLM Config using  env variable LLM_CONFIG_ADMIN_ONLY backward compatibility ,  default value is N  everyone has access Display version next to UNLA

Display application version on ui page on top righ next to Unla

## Summary by Sourcery

Add environment-based access control for the LLM Config menu and display the application version in the UI layout.

New Features:
- Introduce LLM_CONFIG_ADMIN_ONLY env var to restrict LLM Config menu visibility to admins when set to 'Y'.
- Show the current application version next to the Unla logo in the top-right of the layout.

Enhancements:
- Include LLM_CONFIG_ADMIN_ONLY and version in the runtime config payload served to the frontend.
- Ensure LLM_CONFIG_ADMIN_ONLY defaults to 'N' on the client side if absent in the runtime config.

Chores:
- Export the embedded VERSION constant in pkg/version and update the runtime handler to use it.
- Rename the version variable in version.go to an exported Version.
- Update .env.example to document the LLM_CONFIG_ADMIN_ONLY variable.