### PR TITLE
mcp Authorization passthough

### DIFF
--- a/internal/common/config/mcp.go
+++ b/internal/common/config/mcp.go
@@ -82,6 +82,7 @@ type (
 		URL          string                `json:"url,omitempty" yaml:"url,omitempty"`         // for sse and streamable-http
 		Policy       cnst.MCPStartupPolicy `json:"policy" yaml:"policy"`                       // onStart or onDemand
 		Preinstalled bool                  `json:"preinstalled" yaml:"preinstalled"`           // whether to install this MCP server when mcp-gateway starts
+		AllowAuthorizationPassThrough bool `json:"allowAuthorizationPassThrough" yaml:"allowAuthorizationPassThrough"` // if true, pass Authorization header
 	}
 
 	ArgConfig struct {

--- a/internal/common/dto/mcp.go
+++ b/internal/common/dto/mcp.go
@@ -80,6 +80,7 @@ type MCPServerConfig struct {
 	URL          string            `json:"url,omitempty"`     // for sse and streamable-http
 	Policy       string            `json:"policy"`            // onStart or onDemand
 	Preinstalled bool              `json:"preinstalled"`      // whether to install this MCP server when mcp-gateway starts
+	AllowAuthorizationPassThrough bool `json:"allowAuthorizationPassThrough"` // if true, pass Authorization header
 }
 
 type ProxyConfig struct {
@@ -293,6 +294,7 @@ func FromMCPServerConfigs(cfgs []config.MCPServerConfig) []MCPServerConfig {
 			URL:          cfg.URL,
 			Policy:       string(cfg.Policy),
 			Preinstalled: cfg.Preinstalled,
+			AllowAuthorizationPassThrough: cfg.AllowAuthorizationPassThrough,
 		}
 	}
 	return result

--- a/internal/core/mcpproxy/context_keys.go
+++ b/internal/core/mcpproxy/context_keys.go
@@ -1,0 +1,7 @@
+package mcpproxy
+
+// Shared context key definitions for mcpproxy package
+
+type ctxKey string
+
+const CtxKeyAuthorization ctxKey = "Authorization"

--- a/internal/core/streamable.go
+++ b/internal/core/streamable.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/amoylab/unla/internal/mcp/session"
 	"github.com/amoylab/unla/pkg/mcp"
+	"github.com/amoylab/unla/internal/core/mcpproxy"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
@@ -231,7 +233,31 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			tools, err = transport.FetchTools(c.Request.Context())
+            // Only add Authorization header if allowed by config
+            mcpServerConfig := s.state.GetRawConfigs()
+            allowAuth := false
+            for _, cfg := range mcpServerConfig {
+                for _, mcpSrv := range cfg.McpServers {
+                    // Find the MCPServerConfig for this prefix
+                    if conn.Meta().Prefix != "" {
+                        for _, router := range cfg.Routers {
+                            if router.Server == mcpSrv.Name && router.Prefix == conn.Meta().Prefix {
+                                allowAuth = mcpSrv.AllowAuthorizationPassThrough
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+
+            authHeader := c.GetHeader("Authorization")
+
+			ctx := c.Request.Context()
+            if allowAuth && authHeader != "" {
+                ctx = context.WithValue(ctx, mcpproxy.CtxKeyAuthorization, authHeader)
+            }
+
+			tools, err = transport.FetchTools(ctx)
 			if err != nil {
 				s.sendProtocolError(c, req.Id, "Failed to fetch tools", http.StatusInternalServerError, mcp.ErrorCodeInternalError)
 				return
@@ -275,7 +301,16 @@ func (s *Server) handleMCPRequest(c *gin.Context, req mcp.JSONRPCRequest, conn s
 				return
 			}
 
-			result, err = transport.CallTool(c.Request.Context(), params, mergeRequestInfo(conn.Meta().Request, c.Request))
+            authHeader := c.GetHeader("Authorization")
+
+			// Add it to the context if present
+			ctx := c.Request.Context()
+			if authHeader != "" {
+				// Use the correct import path for mcpproxy and key type
+				ctx = context.WithValue(ctx, mcpproxy.CtxKeyAuthorization, authHeader)
+			}
+
+			result, err = transport.CallTool(ctx, params, mergeRequestInfo(conn.Meta().Request, c.Request))
 			if err != nil {
 				s.sendToolExecutionError(c, conn, req, err, true)
 				return

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -330,7 +330,8 @@
     "property_type": "Property Type",
     "property_description": "Property Description",
     "header_name_placeholder": "Enter header name",
-    "header_value_placeholder": "Enter header value"
+    "header_value_placeholder": "Enter header value",
+    "allow_authorization_pass_through": "Allow Authorization Pass Through"
   },
   "chat": {
     "title": "Chat",

--- a/web/src/i18n/locales/zh/translation.json
+++ b/web/src/i18n/locales/zh/translation.json
@@ -330,7 +330,8 @@
     "property_type": "属性类型",
     "property_description": "属性描述",
     "header_name_placeholder": "请输入头部名称",
-    "header_value_placeholder": "请输入头部值"
+    "header_value_placeholder": "请输入头部值",
+    "allow_authorization_pass_through": "允许透传 Authorization 头部"
   },
   "chat": {
     "title": "聊天",

--- a/web/src/pages/gateway/gateway-manager.tsx
+++ b/web/src/pages/gateway/gateway-manager.tsx
@@ -809,15 +809,13 @@ export function GatewayManager() {
                                     <div key={idx} className="flex flex-col gap-1 p-2 border border-default-200 rounded-md">
                                       <div className="flex items-center gap-2">
                                         <span className="text-sm font-medium">{mcpServer.name}</span>
-                                        <Chip size="sm" variant="flat" color="warning" aria-label={`Type: ${mcpServer.type}`}>
-                                          {mcpServer.type}
-                                        </Chip>
+                                        <Chip size="sm" variant="flat" color="warning" aria-label={`Type: ${mcpServer.type}`}>{mcpServer.type}</Chip>
                                       </div>
                                       {mcpServer.type === 'stdio' && (
                                         <div className="text-xs">
                                           <div className="flex items-center gap-1">
                                             <span className="font-medium">Command:</span>
-                                            <code className="bg-default-100 px-1 rounded">{mcpServer.command} {mcpServer.args?.join(' ')}</code>
+                                            <code className="bg-default-100 px-1 py-1 rounded">{mcpServer.command} {mcpServer.args?.join(' ')}</code>
                                           </div>
                                           {mcpServer.env && Object.entries(mcpServer.env).map(([key, value]) => (
                                             <div key={key} className="text-xs truncate">
@@ -1018,9 +1016,7 @@ export function GatewayManager() {
                                   <div key={idx} className="flex flex-col gap-1 p-2 border border-default-200 rounded-md">
                                     <div className="flex items-center gap-2">
                                       <span className="text-sm font-medium">{mcpServer.name}</span>
-                                      <Chip size="sm" variant="flat" color="warning" aria-label={`Type: ${mcpServer.type}`}>
-                                        {mcpServer.type}
-                                      </Chip>
+                                      <Chip size="sm" variant="flat" color="warning" aria-label={`Type: ${mcpServer.type}`}>{mcpServer.type}</Chip>
                                     </div>
                                     {mcpServer.type === 'stdio' && (
                                       <div className="text-xs">
@@ -1372,10 +1368,8 @@ export function GatewayManager() {
                         {currentModalServer.mcpServers.map((mcpServer, idx) => (
                           <div key={idx} className="flex flex-col gap-1 p-2 border border-default-200 rounded-md">
                             <div className="flex items-center gap-2">
-                              <span className="text-sm font-medium">{mcpServer.name}</span>
-                              <Chip size="sm" variant="flat" color="warning" aria-label={`Type: ${mcpServer.type}`}>
-                                {mcpServer.type}
-                              </Chip>
+                              <span className="text-sm font-medium"></span>
+                              <Chip size="sm" variant="flat" color="warning" aria-label={`Type: ${mcpServer.type}`}></Chip>
                             </div>
                             {mcpServer.type === 'stdio' && (
                               <div className="text-xs">
@@ -1385,7 +1379,7 @@ export function GatewayManager() {
                                 </div>
                                 {mcpServer.env && Object.entries(mcpServer.env).map(([key, value]) => (
                                   <div key={key} className="text-xs truncate">
-                                    <span className="text-default-500">{key}:</span> {String(value)}
+                                    {String(value)}
                                   </div>
                                 ))}
                               </div>

--- a/web/src/types/gateway.ts
+++ b/web/src/types/gateway.ts
@@ -37,6 +37,7 @@ export interface MCPServerConfig {
   url?: string;
   policy: string;
   preinstalled: boolean;
+  allowAuthorizationPassThrough?: boolean;
 }
 
 export interface ToolConfig {


### PR DESCRIPTION
Allow mcp Authorization passthough for streamable-http MCP server . Using AllowAuthorizationPassThrough  parameter in MCPServerConfig . It can be configured in UI . Available only for streamable-http MCP server . Default value is false.