### PR TITLE
feat: support multi redis addr seperator

### DIFF
--- a/internal/auth/storage/redis.go
+++ b/internal/auth/storage/redis.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 
 	"github.com/amoylab/unla/internal/common/cnst"
 	"github.com/amoylab/unla/internal/common/errorx"
+	"github.com/amoylab/unla/pkg/utils"
 )
 
 // RedisStorage implements the Store interface using Redis
@@ -20,7 +20,7 @@ type RedisStorage struct {
 
 // NewRedisStorage creates a new Redis storage instance
 func NewRedisStorage(clusterType, addr, masterName string, username, password string, db int) (*RedisStorage, error) {
-	addrs := strings.Split(addr, ";")
+	addrs := utils.SplitByMultipleDelimiters(addr, ";", ",")
 	redisOptions := &redis.UniversalOptions{
 		Addrs:    addrs,
 		Username: username,

--- a/internal/mcp/session/redis.go
+++ b/internal/mcp/session/redis.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/amoylab/unla/internal/common/cnst"
 	"github.com/amoylab/unla/internal/common/config"
+	"github.com/amoylab/unla/pkg/utils"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -34,7 +34,7 @@ var _ Store = (*RedisStore)(nil)
 // NewRedisStore creates a new Redis-based session store
 // func NewRedisStore(logger *zap.Logger, addr, username, password string, db int, topic string) (*RedisStore, error) {
 func NewRedisStore(logger *zap.Logger, cfg config.SessionRedisConfig) (*RedisStore, error) {
-	addrs := strings.Split(cfg.Addr, ";")
+	addrs := utils.SplitByMultipleDelimiters(cfg.Addr, ";", ",")
 	redisOptions := &redis.UniversalOptions{
 		Addrs:    addrs,
 		Username: cfg.Username,

--- a/internal/mcp/storage/notifier/redis.go
+++ b/internal/mcp/storage/notifier/redis.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/amoylab/unla/internal/common/cnst"
+	"github.com/amoylab/unla/pkg/utils"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -24,7 +24,7 @@ type RedisNotifier struct {
 
 // NewRedisNotifier creates a new Redis-based notifier
 func NewRedisNotifier(logger *zap.Logger, clusterType, addr, masterName, username, password string, db int, topic string, role config.NotifierRole) (*RedisNotifier, error) {
-	addrs := strings.Split(addr, ";")
+	addrs := utils.SplitByMultipleDelimiters(addr, ";", ",")
 	redisOptions := &redis.UniversalOptions{
 		Addrs:    addrs,
 		Username: username,

--- a/pkg/utils/str.go
+++ b/pkg/utils/str.go
@@ -16,6 +16,9 @@ func FirstNonEmpty(str1, str2 string) string {
 }
 
 func SplitByMultipleDelimiters(s string, delimiters ...string) []string {
+	if len(delimiters) == 0 {
+		return []string{s}
+	}
 	delimiterPattern := "[" + regexp.QuoteMeta(strings.Join(delimiters, "")) + "]"
 	re := regexp.MustCompile(delimiterPattern)
 	return re.Split(s, -1)

--- a/pkg/utils/str.go
+++ b/pkg/utils/str.go
@@ -1,5 +1,10 @@
 package utils
 
+import (
+	"regexp"
+	"strings"
+)
+
 func FirstNonEmpty(str1, str2 string) string {
 	if str1 != "" {
 		return str1
@@ -8,4 +13,10 @@ func FirstNonEmpty(str1, str2 string) string {
 		return str2
 	}
 	return ""
+}
+
+func SplitByMultipleDelimiters(s string, delimiters ...string) []string {
+	delimiterPattern := "[" + regexp.QuoteMeta(strings.Join(delimiters, "")) + "]"
+	re := regexp.MustCompile(delimiterPattern)
+	return re.Split(s, -1)
 }

--- a/pkg/utils/str_test.go
+++ b/pkg/utils/str_test.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"testing"
+)
+import "github.com/stretchr/testify/assert"
+
+func TestSplitByMultipleDelimiters(t *testing.T) {
+	input := "a,b;c"
+	delimiters := []string{",", ";"}
+	expected := []string{"a", "b", "c"}
+	result := SplitByMultipleDelimiters(input, delimiters...)
+	assert.Equal(t, expected, result)
+	input = "a,b=c"
+	expected = []string{"a", "b=c"}
+	result = SplitByMultipleDelimiters(input, delimiters...)
+	assert.Equal(t, expected, result)
+	input = "a"
+	expected = []string{"a"}
+	result = SplitByMultipleDelimiters(input, delimiters...)
+	assert.Equal(t, expected, result)
+}

--- a/pkg/utils/str_test.go
+++ b/pkg/utils/str_test.go
@@ -19,4 +19,8 @@ func TestSplitByMultipleDelimiters(t *testing.T) {
 	expected = []string{"a"}
 	result = SplitByMultipleDelimiters(input, delimiters...)
 	assert.Equal(t, expected, result)
+	input = "a,b"
+	expected = []string{"a,b"}
+	result = SplitByMultipleDelimiters(input)
+	assert.Equal(t, expected, result)
 }


### PR DESCRIPTION
## Summary by Sourcery

Add support for parsing multiple Redis address separators by introducing a generic splitting utility and applying it to all Redis clients

New Features:
- Add SplitByMultipleDelimiters function to utility package

Enhancements:
- Update Redis storage, session store, and notifier to accept both ";" and "," as address delimiters

Tests:
- Include unit tests for SplitByMultipleDelimiters function