### PR TITLE
Chat page add SystemPrompt and Authorization Textbox

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -167,6 +167,7 @@ func initRouter(db database.Database, store storage.Store, ntf notifier.Notifier
 		chatHandler := apiserverHandler.NewChat(db, logger)
 		mcpHandler := apiserverHandler.NewMCP(db, store, ntf, logger)
 		openapiHandler := apiserverHandler.NewOpenAPI(db, store, ntf, logger)
+		systemPromptHandler := apiserverHandler.NewSystemPrompt(db, logger)
 
 		// Auth routes
 		protected.POST("/auth/change-password", authH.ChangePassword)

--- a/internal/apiserver/database/database.go
+++ b/internal/apiserver/database/database.go
@@ -48,4 +48,8 @@ type Database interface {
 	DeleteUserTenants(ctx context.Context, userID uint) error
 
 	Transaction(ctx context.Context, fn func(ctx context.Context) error) error
+
+	// System prompt methods
+	GetSystemPrompt(ctx context.Context, userID uint) (string, error)
+	SaveSystemPrompt(ctx context.Context, userID uint, prompt string) error
 }

--- a/internal/apiserver/database/model.go
+++ b/internal/apiserver/database/model.go
@@ -59,3 +59,14 @@ type UserTenant struct {
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }
+
+// SystemPrompt stores a user's system prompt
+// UserID is a foreign key to User.ID and is the primary key
+// Prompt is the text of the system prompt
+// UpdatedAt is the last update time
+// TableName: system_prompts
+type SystemPrompt struct {
+	UserID    uint      `json:"userId" gorm:"primaryKey;index;not null"`
+	Prompt    string    `json:"prompt" gorm:"type:text;not null"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}

--- a/internal/apiserver/database/mysql.go
+++ b/internal/apiserver/database/mysql.go
@@ -28,7 +28,8 @@ func NewMySQL(cfg *config.DatabaseConfig) (Database, error) {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
-	if err := gormDB.AutoMigrate(&Message{}, &Session{}, &User{}, &Tenant{}, &UserTenant{}); err != nil {
+	// Add SystemPrompt to migrations
+	if err := gormDB.AutoMigrate(&Message{}, &Session{}, &User{}, &Tenant{}, &UserTenant{}, &SystemPrompt{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
@@ -273,4 +274,34 @@ func (db *MySQL) DeleteUserTenants(ctx context.Context, userID uint) error {
 	dbSession := getDBFromContext(ctx, db.db)
 
 	return dbSession.Where("user_id = ?", userID).Delete(&UserTenant{}).Error
+}
+
+// --- SystemPrompt persistent methods ---
+
+func (db *MySQL) GetSystemPrompt(ctx context.Context, userID uint) (string, error) {
+	var sp SystemPrompt
+	err := db.db.WithContext(ctx).Where("user_id = ?", userID).First(&sp).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", nil // No prompt set yet
+		}
+		return "", err
+	}
+	return sp.Prompt, nil
+}
+
+func (db *MySQL) SaveSystemPrompt(ctx context.Context, userID uint, prompt string) error {
+	var sp SystemPrompt
+	err := db.db.WithContext(ctx).Where("user_id = ?", userID).First(&sp).Error
+	now := time.Now()
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			sp = SystemPrompt{UserID: userID, Prompt: prompt, UpdatedAt: now}
+			return db.db.WithContext(ctx).Create(&sp).Error
+		}
+		return err
+	}
+	sp.Prompt = prompt
+	sp.UpdatedAt = now
+	return db.db.WithContext(ctx).Save(&sp).Error
 }

--- a/internal/apiserver/database/sqlite.go
+++ b/internal/apiserver/database/sqlite.go
@@ -35,7 +35,8 @@ func NewSQLite(cfg *config.DatabaseConfig) (Database, error) {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
-	if err := gormDB.AutoMigrate(&Message{}, &Session{}, &User{}, &Tenant{}, &UserTenant{}); err != nil {
+	// Add SystemPrompt to migrations
+	if err := gormDB.AutoMigrate(&Message{}, &Session{}, &User{}, &Tenant{}, &UserTenant{}, &SystemPrompt{}); err != nil {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
@@ -280,4 +281,34 @@ func (db *SQLite) DeleteUserTenants(ctx context.Context, userID uint) error {
 	dbSession := getDBFromContext(ctx, db.db)
 
 	return dbSession.Where("user_id = ?", userID).Delete(&UserTenant{}).Error
+}
+
+// --- SystemPrompt persistent methods ---
+
+func (db *SQLite) GetSystemPrompt(ctx context.Context, userID uint) (string, error) {
+	var sp SystemPrompt
+	err := db.db.WithContext(ctx).Where("user_id = ?", userID).First(&sp).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", nil // No prompt set yet
+		}
+		return "", err
+	}
+	return sp.Prompt, nil
+}
+
+func (db *SQLite) SaveSystemPrompt(ctx context.Context, userID uint, prompt string) error {
+	var sp SystemPrompt
+	err := db.db.WithContext(ctx).Where("user_id = ?", userID).First(&sp).Error
+	now := time.Now()
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			sp = SystemPrompt{UserID: userID, Prompt: prompt, UpdatedAt: now}
+			return db.db.WithContext(ctx).Create(&sp).Error
+		}
+		return err
+	}
+	sp.Prompt = prompt
+	sp.UpdatedAt = now
+	return db.db.WithContext(ctx).Save(&sp).Error
 }

--- a/internal/apiserver/handler/systemprompt.go
+++ b/internal/apiserver/handler/systemprompt.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"net/http"
+	"github.com/gin-gonic/gin"
+	"github.com/amoylab/unla/internal/apiserver/database"
+	"github.com/amoylab/unla/internal/i18n"
+	"github.com/amoylab/unla/internal/auth/jwt"
+	"go.uber.org/zap"
+)
+
+type SystemPrompt struct {
+	db     database.Database
+	logger *zap.Logger
+}
+
+func NewSystemPrompt(db database.Database, logger *zap.Logger) *SystemPrompt {
+	return &SystemPrompt{db: db, logger: logger.Named("apiserver.handler.systemprompt")}
+}
+
+// GetSystemPrompt returns the system prompt for the current user
+func (h *SystemPrompt) GetSystemPrompt(c *gin.Context) {
+	claims, exists := c.Get("claims")
+	if !exists {
+		h.logger.Warn("missing claims in context", zap.String("remote_addr", c.ClientIP()))
+		i18n.RespondWithError(c, i18n.ErrUnauthorized)
+		return
+	}
+	jwtClaims := claims.(*jwt.Claims)
+	user, err := h.db.GetUserByUsername(c.Request.Context(), jwtClaims.Username)
+	if err != nil {
+		h.logger.Error("failed to get user info", zap.String("username", jwtClaims.Username), zap.Error(err))
+		i18n.RespondWithError(c, i18n.ErrInternalServer.WithParam("Reason", "Failed to get user info: "+err.Error()))
+		return
+	}
+	h.logger.Info("retrieving system prompt", zap.Uint("user_id", user.ID), zap.String("remote_addr", c.ClientIP()))
+	prompt, err := h.db.GetSystemPrompt(c.Request.Context(), user.ID)
+	if err != nil {
+		h.logger.Error("failed to get system prompt", zap.Error(err), zap.Uint("user_id", user.ID), zap.String("remote_addr", c.ClientIP()))
+		i18n.RespondWithError(c, i18n.ErrInternalServer.WithParam("Reason", err.Error()))
+		return
+	}
+	h.logger.Debug("successfully retrieved system prompt", zap.Uint("user_id", user.ID), zap.String("remote_addr", c.ClientIP()))
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"prompt": prompt}})
+}
+
+// SaveSystemPrompt saves the system prompt for the current user
+func (h *SystemPrompt) SaveSystemPrompt(c *gin.Context) {
+	claims, exists := c.Get("claims")
+	if !exists {
+		h.logger.Warn("missing claims in context", zap.String("remote_addr", c.ClientIP()))
+		i18n.RespondWithError(c, i18n.ErrUnauthorized)
+		return
+	}
+	jwtClaims := claims.(*jwt.Claims)
+	user, err := h.db.GetUserByUsername(c.Request.Context(), jwtClaims.Username)
+	if err != nil {
+		h.logger.Error("failed to get user info", zap.String("username", jwtClaims.Username), zap.Error(err))
+		i18n.RespondWithError(c, i18n.ErrInternalServer.WithParam("Reason", "Failed to get user info: "+err.Error()))
+		return
+	}
+	var req struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.logger.Warn("invalid request body", zap.Error(err), zap.Uint("user_id", user.ID), zap.String("remote_addr", c.ClientIP()))
+		i18n.RespondWithError(c, i18n.ErrBadRequest.WithParam("Reason", err.Error()))
+		return
+	}
+	h.logger.Info("saving system prompt", zap.Uint("user_id", user.ID), zap.String("remote_addr", c.ClientIP()))
+	if err := h.db.SaveSystemPrompt(c.Request.Context(), user.ID, req.Prompt); err != nil {
+		h.logger.Error("failed to save system prompt", zap.Error(err), zap.Uint("user_id", user.ID), zap.String("remote_addr", c.ClientIP()))
+		i18n.RespondWithError(c, i18n.ErrInternalServer.WithParam("Reason", err.Error()))
+		return
+	}
+	h.logger.Debug("successfully saved system prompt", zap.Uint("user_id", user.ID), zap.String("remote_addr", c.ClientIP()))
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/web/public/icons/icon-map.json
+++ b/web/public/icons/icon-map.json
@@ -36,6 +36,7 @@
   "lucide:upload": "/icons/lucide-upload.svg",
   "lucide:play": "/icons/lucide-play.svg",
   "lucide:alert-triangle": "/icons/lucide-alert-triangle.svg",
+  "lucide:pencil": "/icons/lucide-pencil.svg",
   "mdi:wechat": "/icons/mdi-wechat.svg",
   "mdi:github": "/icons/mdi-github.svg",
   "mdi:book-open-page-variant": "/icons/mdi-book-open-page-variant.svg",

--- a/web/public/icons/lucide-pencil.svg
+++ b/web/public/icons/lucide-pencil.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497zM15 5l4 4"/></svg>

--- a/web/scripts/download-icons.js
+++ b/web/scripts/download-icons.js
@@ -18,6 +18,7 @@ const icons = [
   'lucide:loader-2', 'lucide:arrow-right', 'lucide:copy', 'lucide:external-link',
   'lucide:send', 'lucide:route', 'lucide:terminal', 'lucide:radio', 'lucide:globe',
   'lucide:wrench', 'lucide:trash', 'lucide:upload', 'lucide:play',
+  'lucide:pencil',
   
   // Material Design icons
   'mdi:wechat', 'mdi:github', 'mdi:book-open-page-variant',

--- a/web/src/i18n/locales/en/translation.json
+++ b/web/src/i18n/locales/en/translation.json
@@ -417,6 +417,10 @@
     "delete_failed": "Failed to delete chat session",
     "rename_session": "Rename Chat Session",
     "session_title_placeholder": "Enter new session title"
+    "systemPrompt": "System Prompt",
+    "systemPromptPlaceholder": "Set a custom system prompt for the assistant (optional)",
+    "authTokenPlaceholder": "Enter authentication token",
+    "authToken": "Authentication Token"
   },
   "users": {
     "title": "User Management",

--- a/web/src/i18n/locales/zh/translation.json
+++ b/web/src/i18n/locales/zh/translation.json
@@ -330,7 +330,9 @@
     "property_type": "属性类型",
     "property_description": "属性描述",
     "header_name_placeholder": "请输入头部名称",
-    "header_value_placeholder": "请输入头部值"
+    "header_value_placeholder": "请输入头部值",
+    "systemPrompt": "系统提示词",
+    "systemPromptPlaceholder": "为助手设置自定义系统提示词（可选）"
   },
   "chat": {
     "title": "聊天",
@@ -416,7 +418,9 @@
     "delete_success": "聊天会话删除成功",
     "delete_failed": "聊天会话删除失败",
     "rename_session": "重命名聊天会话",
-    "session_title_placeholder": "请输入新的会话标题"
+    "session_title_placeholder": "请输入新的会话标题",
+    "authTokenPlaceholder": "请输入认证令牌",
+    "authToken": "认证令牌"
   },
   "users": {
     "title": "用户管理",

--- a/web/src/icons/icon-map.json
+++ b/web/src/icons/icon-map.json
@@ -36,6 +36,7 @@
   "lucide:play": "/icons/lucide-play.svg",
   "lucide:brain": "/icons/lucide-brain.svg",
   "lucide:alert-triangle": "/icons/lucide-alert-triangle.svg",
+  "lucide:pencil": "/icons/lucide-pencil.svg",
   "mdi:wechat": "/icons/mdi-wechat.svg",
   "mdi:github": "/icons/mdi-github.svg",
   "mdi:book-open-page-variant": "/icons/mdi-book-open-page-variant.svg",

--- a/web/src/pages/chat/components/chat-message.tsx
+++ b/web/src/pages/chat/components/chat-message.tsx
@@ -33,7 +33,9 @@ export function ChatMessage({ message, messages, onToolCall }: ChatMessageProps)
 
   const handleRunTool = async (tool: ToolCall) => {
     try {
-      if (!tool?.function?.name) {
+      // Use originalName if present, else fallback
+      const toolNameForParsing = (tool?.function as any)?.originalName || tool?.function?.name;
+      if (!toolNameForParsing) {
         toast.error(t('errors.invalid_tool_name'), {
           duration: 3000,
         });
@@ -41,7 +43,7 @@ export function ChatMessage({ message, messages, onToolCall }: ChatMessageProps)
       }
 
       // Parse serverName:toolName format
-      const [serverName, toolName] = tool.function.name.split(':');
+      const [serverName, toolName] = toolNameForParsing.split(':');
       if (!serverName || !toolName) {
         toast.error(t('errors.invalid_tool_name'), {
           duration: 3000,
@@ -171,6 +173,7 @@ export function ChatMessage({ message, messages, onToolCall }: ChatMessageProps)
         )}
         {message.toolCalls?.filter(tool => tool?.function?.name).map((tool, index) => {
           const toolResult = findToolResult(tool.id);
+          const toolDisplayName = (tool.function as any).originalName || tool.function.name;
           return (
             <div key={index} className="mt-3 border border-blue-200 dark:border-blue-800 rounded-lg bg-blue-50/50 dark:bg-blue-950/20 overflow-hidden">
               <div className="flex items-center justify-between p-3 bg-blue-100/70 dark:bg-blue-900/30 border-b border-blue-200 dark:border-blue-800">
@@ -179,7 +182,7 @@ export function ChatMessage({ message, messages, onToolCall }: ChatMessageProps)
                     <LocalIcon icon="lucide:wrench" className="w-3 h-3 text-white" />
                   </div>
                   <span className="font-medium text-blue-900 dark:text-blue-100 text-sm">
-                    {tool.function.name}
+                    {toolDisplayName}
                   </span>
                 </div>
                 {toolResult ? (

--- a/web/src/pages/gateway/components/OpenAPIImport.tsx
+++ b/web/src/pages/gateway/components/OpenAPIImport.tsx
@@ -5,8 +5,8 @@ import { useDropzone } from 'react-dropzone';
 
 import LocalIcon from '@/components/LocalIcon';
 import { importOpenAPI, getTenants } from '@/services/api';
-import { toast } from "@/utils/toast.ts";
 import type { Tenant } from '@/types/gateway';
+import { toast } from "@/utils/toast.ts";
 
 interface OpenAPIImportProps {
   onSuccess?: () => void;

--- a/web/src/services/systemprompt.ts
+++ b/web/src/services/systemprompt.ts
@@ -1,0 +1,10 @@
+import api from './api';
+
+export const getSystemPrompt = async (): Promise<string> => {
+  const response = await api.get('/chat/systemprompt');
+  return response.data.data?.prompt || '';
+};
+
+export const saveSystemPrompt = async (prompt: string): Promise<void> => {
+  await api.put('/chat/systemprompt', { prompt });
+};


### PR DESCRIPTION
In Chat page add SystemPrompt and Authorization Textbox.
User has ability to add SystemPrompt & Authorization Code in Chat
SystemPrompt is send to llm with user input message.
Authorization textbox value is passthrough to  the Rest API
SystemPrompt is saved to database,

## Summary by Sourcery

Add a customizable system prompt feature and authorization token support to the chat interface, including persistence, API endpoints, and UI enhancements.

New Features:
- Introduce a system prompt input and modal in the chat UI with REST endpoints to load and save prompts per user
- Add an authorization token textbox in the chat UI and pass the token into MCPService.connect for authenticated tool connections
- Implement new database migrations, model, and persistence methods for SystemPrompt across MySQL, Postgres, and SQLite
- Expose API handlers and client services for getting and saving the system prompt

Enhancements:
- Sanitize and map tool names for external LLM providers with helper functions and preserve original names in tool calls
- Unify state updates in message handling to use typed callback patterns and filter out incomplete bot messages
- Extend MCPService.connect to accept custom auth headers and add reconnection options