### PR TITLE
Create default llm provider using env variables OPENAI_*

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -220,6 +220,9 @@ func initRouter(db database.Database, store storage.Store, ntf notifier.Notifier
 		protected.DELETE("/chat/sessions/:sessionId", chatHandler.HandleDeleteChatSession)
 		protected.PUT("/chat/sessions/:sessionId/title", chatHandler.HandleUpdateChatSessionTitle)
 		protected.POST("/chat/messages", chatHandler.HandleSaveChatMessage)
+
+		// Default LLM provider endpoint
+		protected.GET("/defaultllmprovider", chatHandler.HandleDefaultLLMProviders)
 	}
 
 	// Public runtime config endpoint for frontend

--- a/internal/apiserver/handler/defaultllmprovider.go
+++ b/internal/apiserver/handler/defaultllmprovider.go
@@ -1,0 +1,57 @@
+package handler
+
+import (
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// HandleDefaultLLMProviders returns only the default LLM provider from ENV in the required format
+func (h *Chat) HandleDefaultLLMProviders(c *gin.Context) {
+	apiKey := strings.TrimSpace(getEnv("OPENAI_API_KEY", ""))
+	baseURL := strings.TrimSpace(getEnv("OPENAI_BASE_URL", ""))
+	model := strings.TrimSpace(getEnv("OPENAI_MODEL", ""))
+
+	var defaultProvider map[string]interface{}
+	if apiKey != "" && baseURL != "" && model != "" {
+		defaultProvider = map[string]interface{}{
+			"id":      "custom_default", // Changed from "default" to "custom_default"
+			"name":    "Default",
+			"apiKey":  apiKey,
+			"baseURL": baseURL,
+			"model":   model,
+			"enabled": true,
+			"config": map[string]interface{}{ // Add default config values
+				"apiKey":     apiKey,
+				"baseURL":    baseURL,
+			},
+			"models": []map[string]interface{}{{ // Add the default model
+				"id":       model,
+				"name":     model,
+				"isCustom": true,
+			}},
+			"settings": map[string]interface{}{ // Only include essential settings
+				"showApiKey":        true,
+				"showBaseURL":       true,
+				"apiKeyRequired":    true,
+				"baseURLRequired":   true,
+			},
+		}
+	}
+
+	var result []interface{}
+	if defaultProvider != nil {
+		result = append(result, defaultProvider)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"configs": result})
+}
+
+func getEnv(key, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultVal
+}

--- a/web/src/pages/llm/llm-settings.tsx
+++ b/web/src/pages/llm/llm-settings.tsx
@@ -78,7 +78,11 @@ const LLMSettings: React.FC = () => {
   const [modelSearchQuery, setModelSearchQuery] = useState('');
   // 搜索过滤后的 provider，启用的在前
   const filteredProviders = providers
-    .filter(provider => {
+    .filter((provider: LLMProvider) => {
+      // Exclude the default provider from the list
+      if (provider.id === 'custom_default') return false;
+      
+      // Then apply search filter
       if (!searchQuery.trim()) return true;
       const query = searchQuery.toLowerCase();
       return (
@@ -86,7 +90,7 @@ const LLMSettings: React.FC = () => {
         (provider.description && provider.description.toLowerCase().includes(query))
       );
     })
-    .sort((a, b) => {
+    .sort((a: LLMProvider, b: LLMProvider) => {
       // 启用的排在前面
       if (a.enabled && !b.enabled) return -1;
       if (!a.enabled && b.enabled) return 1;


### PR DESCRIPTION
Create default llm provider using env variables OPENAI_*

## Summary by Sourcery

Expose a default LLM provider built from OPENAI_* env vars via a new backend endpoint and integrate it into the frontend LLM configuration hook, merging it with saved or built-in providers.

New Features:
- Expose a `/defaultllmprovider` API endpoint that derives a default LLM provider from OPENAI_* environment variables
- Fetch and integrate the default LLM provider into the frontend `useLLMConfig` hook on mount

Enhancements:
- Merge the fetched default provider into the existing provider list and enable consistent config/model deduplication
- Rerun and adapt the LLM config loading logic when the default provider updates and return `defaultProvider` from the hook