### PR TITLE
解决docker compose文件不指定版本时，在旧版本docker-compose二进制上运行报错问题

### DIFF
--- a/deploy/docker/allinone/docker-compose.yml
+++ b/deploy/docker/allinone/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   mcp-gateway:
     image: ${IMAGE:-ghcr.io/amoylab/unla/allinone:latest}

--- a/deploy/docker/multi/docker-compose.yml
+++ b/deploy/docker/multi/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   postgres:
     image: postgres:16


### PR DESCRIPTION
docker-compose.yml不指定版本时，在旧版docker-compose上会报错
![image](https://github.com/user-attachments/assets/1f0921c6-31c8-46c2-a85b-49a3439be342)
增加版本后，可正常运行：
![image](https://github.com/user-attachments/assets/8e298c07-0966-4e3a-bc76-c0821da59fc2)

## Summary by Sourcery

Bug Fixes:
- Specify version 3 in allinone and multi docker-compose files to fix errors on older docker-compose versions