### PR TITLE
fix: Prevent Chrome from autofilling password in search and API key inputs

### DIFF
--- a/web/src/pages/llm/llm-settings.tsx
+++ b/web/src/pages/llm/llm-settings.tsx
@@ -559,6 +559,7 @@ const LLMSettings: React.FC = () => {
               startContent={<Search className="w-4 h-4 text-gray-400" />}
               className="flex-1"
               size="sm"
+              autoComplete="off"
             />
             <Button
               color="primary"
@@ -683,6 +684,7 @@ const LLMSettings: React.FC = () => {
                     onChange={(e) => setConfig((prev: Record<string, unknown>) => ({ ...prev, apiKey: e.target.value }))}
                     type={showApiKey ? 'text' : 'password'}
                     isRequired={selectedProvider.settings.apiKeyRequired}
+                    autoComplete="new-password"
                     endContent={
                       <Button
                         size="sm"


### PR DESCRIPTION
fix: Prevent Chrome from autofilling password in search and API key inputs (#182)

This PR addresses the issue where Chrome browser automatically fills in login passwords into the "Search Provider" input box and the API Key input field in the LLM settings page.

To resolve this, `autoComplete` attributes have been added to the respective `Input` components in `web/src/pages/llm/llm-settings.tsx`:
 - The "Search Provider" input now has `autoComplete="off"`.
 - The API Key input now has `autoComplete="new-password"`.

Closes #182.