### PR TITLE
feat: improve auth code grant with expiry checks and specific errors

### DIFF
--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -266,7 +266,12 @@ func (s *oauth) handleAuthorizationCodeGrant(ctx context.Context, r *http.Reques
 	// Get authorization code
 	authCode, err := s.store.GetAuthorizationCode(ctx, code)
 	if err != nil {
-		return nil, errorx.ErrInvalidGrant
+		return nil, err
+	}
+
+	// Validate client ID
+	if authCode.ClientID != client.ID {
+		return nil, errorx.ErrInvalidClient
 	}
 
 	// Validate redirect URI

--- a/internal/auth/storage/memory_test.go
+++ b/internal/auth/storage/memory_test.go
@@ -47,7 +47,7 @@ func TestMemoryStorage_AuthorizationCode_Flow(t *testing.T) {
 	code2 := &AuthorizationCode{Code: "code2", ExpiresAt: time.Now().Add(-1 * time.Second).Unix()}
 	assert.NoError(t, s.SaveAuthorizationCode(ctx, code2))
 	_, err = s.GetAuthorizationCode(ctx, "code2")
-	assert.ErrorIs(t, err, errorx.ErrInvalidGrant)
+	assert.ErrorIs(t, err, errorx.ErrAuthorizationCodeExpired)
 }
 
 func TestMemoryStorage_Token_Flow(t *testing.T) {
@@ -67,7 +67,7 @@ func TestMemoryStorage_Token_Flow(t *testing.T) {
 	tok2 := &Token{AccessToken: "t2", ClientID: "c2", ExpiresAt: time.Now().Add(-1 * time.Second).Unix()}
 	assert.NoError(t, s.SaveToken(ctx, tok2))
 	_, err = s.GetToken(ctx, "t2")
-	assert.ErrorIs(t, err, errorx.ErrInvalidGrant)
+	assert.ErrorIs(t, err, errorx.ErrTokenExpired)
 
 	// DeleteTokensByClientID
 	_ = s.SaveToken(ctx, &Token{AccessToken: "t3", ClientID: "c3", ExpiresAt: time.Now().Add(5 * time.Second).Unix()})

--- a/internal/auth/storage/redis.go
+++ b/internal/auth/storage/redis.go
@@ -154,7 +154,7 @@ func (s *RedisStorage) GetAuthorizationCode(ctx context.Context, code string) (*
 
 	if authCode.ExpiresAt < time.Now().Unix() {
 		s.client.Del(ctx, authorizationCodePrefix+code)
-		return nil, errorx.ErrInvalidGrant
+		return nil, errorx.ErrAuthorizationCodeExpired
 	}
 
 	return &authCode, nil
@@ -202,7 +202,7 @@ func (s *RedisStorage) GetToken(ctx context.Context, accessToken string) (*Token
 
 	if token.ExpiresAt < time.Now().Unix() {
 		s.client.Del(ctx, tokenPrefix+accessToken)
-		return nil, errorx.ErrInvalidGrant
+		return nil, errorx.ErrTokenExpired
 	}
 
 	return &token, nil

--- a/internal/auth/storage/redis_test.go
+++ b/internal/auth/storage/redis_test.go
@@ -67,7 +67,7 @@ func TestRedisStorage_AuthorizationCode_Flow(t *testing.T) {
 	code2 := &AuthorizationCode{Code: "code2", ExpiresAt: time.Now().Add(-1 * time.Second).Unix()}
 	assert.NoError(t, s.SaveAuthorizationCode(ctx, code2))
 	_, err = s.GetAuthorizationCode(ctx, "code2")
-	assert.ErrorIs(t, err, errorx.ErrInvalidGrant)
+	assert.ErrorIs(t, err, errorx.ErrAuthorizationCodeExpired)
 }
 
 func TestRedisStorage_Token_Flow(t *testing.T) {
@@ -89,7 +89,7 @@ func TestRedisStorage_Token_Flow(t *testing.T) {
 	tok2 := &Token{AccessToken: "t2", ClientID: "c2", ExpiresAt: time.Now().Add(-1 * time.Second).Unix()}
 	assert.NoError(t, s.SaveToken(ctx, tok2))
 	_, err = s.GetToken(ctx, "t2")
-	assert.ErrorIs(t, err, errorx.ErrInvalidGrant)
+	assert.ErrorIs(t, err, errorx.ErrTokenExpired)
 
 	// DeleteTokensByClientID
 	_ = s.SaveToken(ctx, &Token{AccessToken: "t3", ClientID: "c3", ExpiresAt: time.Now().Add(5 * time.Second).Unix()})


### PR DESCRIPTION
- Change error returns for expired authorization codes and tokens from "invalid_grant" to more specific errors ("authorization_code_expired" and "token_expired")
- Add client ID validation for authorization code grant flow
- Improve expiry logic in memory storage with TOCTOU protection
- Update unit tests to check for new error types for expired codes and tokens
- Add new tests for edge cases in authorization code expiry and client ID validation