### PR TITLE
feat: strengthen JWT service initialization and error handling

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -151,10 +151,13 @@ func initRouter(ctx context.Context, db database.Database, store storage.Store, 
 	}
 
 	// Initialize auth services
-	jwtService := jwt.NewService(jwt.Config{
+	jwtService, err := jwt.NewService(jwt.Config{
 		SecretKey: cfg.JWT.SecretKey,
 		Duration:  cfg.JWT.Duration,
 	})
+	if err != nil {
+		logger.Fatal("Failed to initialize JWT service", zap.Error(err))
+	}
 
 	// Initialize OAuth auth service
 	authService, err := auth.NewAuth(logger, cfg.Auth)

--- a/internal/apiserver/handler/auth_handler_test.go
+++ b/internal/apiserver/handler/auth_handler_test.go
@@ -69,7 +69,7 @@ func TestAuthHandler_Login_And_ChangePassword(t *testing.T) {
 	hpwd, _ := bcrypt.GenerateFromPassword([]byte(pwd), bcrypt.DefaultCost)
 	db := &authDBMock{user: &database.User{ID: 1, Username: "u", Password: string(hpwd), Role: database.RoleAdmin, IsActive: true, CreatedAt: time.Now(), UpdatedAt: time.Now()}}
 
-	jwtSvc := jsvc.NewService(jsvc.Config{SecretKey: "k", Duration: time.Hour})
+	jwtSvc, _ := jsvc.NewService(jsvc.Config{SecretKey: "this-is-a-very-long-secret-key-for-testing", Duration: time.Hour})
 	h := NewHandler(db, jwtSvc, &config.MCPGatewayConfig{}, zap.NewNop())
 
 	// Login

--- a/internal/apiserver/handler/oauth_login_test.go
+++ b/internal/apiserver/handler/oauth_login_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/amoylab/unla/internal/auth"
 	jsvc "github.com/amoylab/unla/internal/auth/jwt"
@@ -20,6 +21,7 @@ func (f *fakeExtOAuth) GetAuthURL(state string) string { return f.url }
 func (f *fakeExtOAuth) ExchangeCode(_ context.Context, _ string) (*auth.ExternalTokenResponse, error) {
 	return nil, nil
 }
+
 func (f *fakeExtOAuth) GetUserInfo(_ context.Context, _ string) (*auth.ExternalUserInfo, error) {
 	return nil, nil
 }
@@ -33,9 +35,11 @@ func (f *fakeAuth) ServerMetadata(r *http.Request) map[string]interface{} { retu
 func (f *fakeAuth) Authorize(ctx context.Context, r *http.Request) (*auth.AuthorizationResponse, error) {
 	return nil, nil
 }
+
 func (f *fakeAuth) Token(ctx context.Context, r *http.Request) (*auth.TokenResponse, error) {
 	return nil, nil
 }
+
 func (f *fakeAuth) Register(ctx context.Context, r *http.Request) (*auth.ClientRegistrationResponse, error) {
 	return nil, nil
 }
@@ -50,7 +54,7 @@ func (f *fakeAuth) IsGitHubOAuthEnabled() bool                            { retu
 
 func TestGoogleAndGitHubLogin_And_Providers(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	svc := jsvc.NewService(jsvc.Config{SecretKey: "k"})
+	svc, _ := jsvc.NewService(jsvc.Config{SecretKey: "this-is-a-very-long-secret-key-for-testing", Duration: time.Hour})
 
 	// Disabled -> 400
 	h := NewOAuthHandler(nil, svc, &fakeAuth{}, zap.NewNop())

--- a/internal/apiserver/handler/test_helper.go
+++ b/internal/apiserver/handler/test_helper.go
@@ -1,0 +1,12 @@
+package handler
+
+import (
+	"time"
+
+	jsvc "github.com/amoylab/unla/internal/auth/jwt"
+)
+
+func mustNewJWTService() *jsvc.Service {
+	s, _ := jsvc.NewService(jsvc.Config{SecretKey: "this-is-a-very-long-secret-key-for-testing", Duration: time.Hour})
+	return s
+}

--- a/internal/apiserver/middleware/jwt_test.go
+++ b/internal/apiserver/middleware/jwt_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
 	"time"
 
 	jsvc "github.com/amoylab/unla/internal/auth/jwt"
@@ -27,7 +26,10 @@ func performRequest(h http.HandlerFunc, headers map[string]string) *httptest.Res
 	return w
 }
 
-var hdrSvc = jsvc.NewService(jsvc.Config{SecretKey: "k", Duration: time.Hour})
+var hdrSvc = func() *jsvc.Service {
+	s, _ := jsvc.NewService(jsvc.Config{SecretKey: "this-is-a-very-long-secret-key-for-testing", Duration: time.Hour})
+	return s
+}()
 
 func TestJWTAuthMiddleware_MissingHeader(t *testing.T) {
 	w := performRequest(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }, nil)


### PR DESCRIPTION
- Add validation for JWT service initialization to ensure a secure, non-empty secret key and positive duration.
- Update JWT service to return errors for invalid algorithm, empty or weak secret keys, and invalid duration.
- Refactor code and tests to handle errors from JWT service initialization.
- Replace test short secret keys with longer, secure ones in test cases.
- Add helper function for JWT service initialization to improve test reliability.
- Expand JWT unit tests for error conditions and token validation scenarios.
- Add missing mock methods in test database implementations for completeness.